### PR TITLE
Fix #30: split labevents into specimen-collected and result events

### DIFF
--- a/src/MIMIC_IV_MEDS/configs/event_configs.yaml
+++ b/src/MIMIC_IV_MEDS/configs/event_configs.yaml
@@ -84,13 +84,28 @@ hosp/hcpcsevents:
         possibly_cpt_code: "code"
 
 hosp/labevents:
-  lab:
+  lab_specimen_collected:
     code:
       - LAB
+      - SPECIMEN_COLLECTED
+      - col(itemid)
+    hadm_id: hadm_id
+    time: col(charttime)
+    time_format: "%Y-%m-%d %H:%M:%S"
+    priority: priority
+    _metadata:
+      d_labitems_to_loinc:
+        description: ["omop_concept_name", "label"] # List of strings are columns to be collated
+        itemid: "itemid (omop_source_code)"
+        parent_codes: "{omop_vocabulary_id}/{omop_concept_code}"
+  lab_result:
+    code:
+      - LAB
+      - RESULT
       - col(itemid)
       - col(valueuom)
     hadm_id: hadm_id
-    time: col(charttime)
+    time: col(storetime)
     time_format: "%Y-%m-%d %H:%M:%S"
     numeric_value: valuenum
     text_value: value


### PR DESCRIPTION
labevents used charttime (specimen collection) for result values, causing time leakage -- the result was timestamped before it was actually available to clinicians. Split into two events:
- LAB//SPECIMEN_COLLECTED at charttime (code + priority only, no values)
- LAB//RESULT at storetime (code + values + metadata)

Audited all other modalities; chartevents, outputevents, and emar use charttime appropriately (actual measurement/event time, not specimen-result gap).