### PR TITLE
Sync dev into main: infra pinning + CI retry

### DIFF
--- a/.github/workflows/code-quality-pr.yaml
+++ b/.github/workflows/code-quality-pr.yaml
@@ -24,10 +24,7 @@ jobs:
 
       - name: Find modified files
         id: file_changes
-        # Pinned to SHA (and not a moving tag) for supply-chain safety: this
-        # action has been the target of a tag-hijack attack in the past, and
-        # GitHub tags are mutable. SHA = v47.0.6.
-        uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
+        uses: tj-actions/changed-files@v47.0.6
 
       - name: List all changed files
         run: echo '${{ steps.file_changes.outputs.all_changed_files }}'

--- a/.github/workflows/code-quality-pr.yaml
+++ b/.github/workflows/code-quality-pr.yaml
@@ -24,7 +24,10 @@ jobs:
 
       - name: Find modified files
         id: file_changes
-        uses: tj-actions/changed-files@v46.0.5
+        # Pinned to SHA (and not a moving tag) for supply-chain safety: this
+        # action has been the target of a tag-hijack attack in the past, and
+        # GitHub tags are mutable. SHA = v47.0.6.
+        uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
 
       - name: List all changed files
         run: echo '${{ steps.file_changes.outputs.all_changed_files }}'

--- a/.github/workflows/python-build.yaml
+++ b/.github/workflows/python-build.yaml
@@ -69,7 +69,7 @@ jobs:
           path: dist/
 
       - name: Sign the dists with Sigstore
-        uses: sigstore/gh-action-sigstore-python@v3.0.0
+        uses: sigstore/gh-action-sigstore-python@v3.3.0
         with:
           inputs: >-
             ./dist/*.tar.gz

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -31,11 +31,11 @@ jobs:
           uv run pytest src/ tests/ -v --doctest-modules --cov=src --junitxml=junit.xml -s
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4.0.1
+        uses: codecov/codecov-action@v5.5.4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v1
+        uses: codecov/test-results-action@v1.2.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -28,14 +28,19 @@ jobs:
 
       - name: Run tests
         run: |
-          uv run pytest src/ tests/ -v --doctest-modules --cov=src --junitxml=junit.xml -s
+          uv run pytest src/ tests/ -v --doctest-modules \
+            --cov=src --cov-report=xml --cov-report=term \
+            --junitxml=junit.xml -s
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5.5.4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage.xml
+          fail_ci_if_error: false
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
         uses: codecov/test-results-action@v1.2.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./junit.xml

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -27,10 +27,19 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Run tests
+        # `--reruns`/`--only-rerun` (from pytest-rerunfailures) retries the
+        # e2e demo-download test when PhysioNet returns mid-stream connection
+        # errors (IncompleteRead / ChunkedEncodingError / ConnectionError).
+        # These are upstream transient failures, not real regressions, and
+        # blocking CI on them means no PR can land during a bad PhysioNet
+        # minute. The pattern is intentionally narrow: anything else fails
+        # hard on first occurrence.
         run: |
           uv run pytest src/ tests/ -v --doctest-modules \
             --cov=src --cov-report=xml --cov-report=term \
-            --junitxml=junit.xml -s
+            --junitxml=junit.xml -s \
+            --reruns 3 --reruns-delay 20 \
+            --only-rerun "IncompleteRead|ChunkedEncodingError|ConnectionError|Connection broken"
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5.5.4

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,22 +47,26 @@ repos:
     hooks:
       - id: shellcheck
 
-  # md formatting
+  # md formatting. `additional_dependencies` (mdformat plugins) are pinned to
+  # exact versions to avoid surprise regressions when plugin patch releases ship;
+  # `shfmt-py` provides a pinned `shfmt` binary to `mdformat-shfmt` so the hook
+  # doesn't silently fall back to whatever system shfmt happens to be on PATH.
   - repo: https://github.com/executablebooks/mdformat
     rev: 0.7.22
     hooks:
       - id: mdformat
         args: ["--number"]
         additional_dependencies:
-          - mdformat-gfm
-          - mdformat-tables
-          - mdformat_frontmatter
-          - mdformat-black
-          - mdformat-config
-          - mdformat-shfmt
-          - mdformat-mkdocs
-          - mdformat-toc
-          - mdformat-gfm-alerts
+          - mdformat-gfm==1.0.0
+          - mdformat-tables==1.0.0
+          - mdformat-frontmatter==2.0.10
+          - mdformat-black==0.1.1
+          - mdformat-config==0.2.1
+          - mdformat-shfmt==0.2.0
+          - mdformat-mkdocs==5.1.4
+          - mdformat-toc==0.5.0
+          - mdformat-gfm-alerts==2.0.0
+          - shfmt-py==3.12.0.2
 
   # word spelling linter
   - repo: https://github.com/codespell-project/codespell

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![PyPI - Version](https://img.shields.io/pypi/v/MIMIC-IV-MEDS)](https://pypi.org/project/MIMIC-IV-MEDS/)
 [![codecov](https://codecov.io/gh/Medical-Event-Data-Standard/MIMIC_IV_MEDS/graph/badge.svg?token=E7H6HKZV3O)](https://codecov.io/gh/Medical-Event-Data-Standard/MIMIC_IV_MEDS)
-[![tests](https://github.com/Medical-Event-Data-Standard/MIMIC_IV_MEDS/actions/workflows/tests.yaml/badge.svg)](https://github.com/Medical-Event-Data-Standard/MIMIC_IV_MEDS/actions/workflows/tests.yml)
+[![tests](https://github.com/Medical-Event-Data-Standard/MIMIC_IV_MEDS/actions/workflows/tests.yaml/badge.svg)](https://github.com/Medical-Event-Data-Standard/MIMIC_IV_MEDS/actions/workflows/tests.yaml)
 [![code-quality](https://github.com/Medical-Event-Data-Standard/MIMIC_IV_MEDS/actions/workflows/code-quality-main.yaml/badge.svg)](https://github.com/Medical-Event-Data-Standard/MIMIC_IV_MEDS/actions/workflows/code-quality-main.yaml)
 ![python](https://img.shields.io/badge/-Python_3.11-blue?logo=python&logoColor=white)
 [![license](https://img.shields.io/badge/License-MIT-green.svg?labelColor=gray)](https://github.com/Medical-Event-Data-Standard/MIMIC_IV_MEDS#license)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,11 @@ dependencies = [
 ]
 
 [dependency-groups]
-dev = ["pre-commit<4", "ruff", "pytest", "pytest-cov"]
+# `shfmt-py` bundles the `shfmt` binary that the `mdformat-shfmt` pre-commit
+# hook shells out to; declaring it here (in addition to pinning it under the
+# mdformat hook's `additional_dependencies`) keeps local + CI behavior in lock
+# step instead of silently falling back to whatever `shfmt` is on the system.
+dev = ["pre-commit<4", "ruff", "pytest", "pytest-cov", "shfmt-py==3.12.0.2"]
 
 [tool.setuptools_scm]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,18 @@ dependencies = [
 # hook shells out to; declaring it here (in addition to pinning it under the
 # mdformat hook's `additional_dependencies`) keeps local + CI behavior in lock
 # step instead of silently falling back to whatever `shfmt` is on the system.
-dev = ["pre-commit<4", "ruff", "pytest", "pytest-cov", "shfmt-py==3.12.0.2"]
+# `pytest-rerunfailures` lets CI auto-retry the e2e demo download test on the
+# narrow set of network exceptions seen coming out of PhysioNet (connection
+# reset / IncompleteRead mid-stream) instead of turning a bad upstream minute
+# into a failed CI build.
+dev = [
+    "pre-commit<4",
+    "ruff",
+    "pytest",
+    "pytest-cov",
+    "pytest-rerunfailures==16.1",
+    "shfmt-py==3.12.0.2",
+]
 
 [tool.setuptools_scm]
 

--- a/uv.lock
+++ b/uv.lock
@@ -507,6 +507,7 @@ dev = [
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pytest-rerunfailures" },
     { name = "ruff" },
     { name = "shfmt-py" },
 ]
@@ -529,6 +530,7 @@ dev = [
     { name = "pre-commit", specifier = "<4" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pytest-rerunfailures", specifier = "==16.1" },
     { name = "ruff" },
     { name = "shfmt-py", specifier = "==3.12.0.2" },
 ]
@@ -799,6 +801,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
+]
+
+[[package]]
+name = "pytest-rerunfailures"
+version = "16.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/de/04/71e9520551fc8fe2cf5c1a1842e4e600265b0815f2016b7c27ec85688682/pytest_rerunfailures-16.1.tar.gz", hash = "sha256:c38b266db8a808953ebd71ac25c381cb1981a78ff9340a14bcb9f1b9bff1899e", size = 30889, upload-time = "2025-10-10T07:06:01.238Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/54/60eabb34445e3db3d3d874dc1dfa72751bfec3265bd611cb13c8b290adea/pytest_rerunfailures-16.1-py3-none-any.whl", hash = "sha256:5d11b12c0ca9a1665b5054052fcc1084f8deadd9328962745ef6b04e26382e86", size = 14093, upload-time = "2025-10-10T07:06:00.019Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -508,6 +508,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "ruff" },
+    { name = "shfmt-py" },
 ]
 
 [package.metadata]
@@ -529,6 +530,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "ruff" },
+    { name = "shfmt-py", specifier = "==3.12.0.2" },
 ]
 
 [[package]]
@@ -1037,6 +1039,12 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/4c/56/5c7084299bd2cacaa07ae63a91c6f4ba66edc08bf28f356b24f6b717c799/ruff-0.15.9-py3-none-win_amd64.whl", hash = "sha256:45a70921b80e1c10cf0b734ef09421f71b5aa11d27404edc89d7e8a69505e43d", size = 11744969, upload-time = "2026-04-02T18:16:59.611Z" },
     { url = "https://files.pythonhosted.org/packages/03/36/76704c4f312257d6dbaae3c959add2a622f63fcca9d864659ce6d8d97d3d/ruff-0.15.9-py3-none-win_arm64.whl", hash = "sha256:0694e601c028fd97dc5c6ee244675bc241aeefced7ef80cd9c6935a871078f53", size = 11005870, upload-time = "2026-04-02T18:17:15.773Z" },
 ]
+
+[[package]]
+name = "shfmt-py"
+version = "3.12.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/d9/a1ea26749bd19467e9fbfe7b34e6c8df517e01de4028a45b954eebe8c03b/shfmt_py-3.12.0.2.tar.gz", hash = "sha256:6a0dc675b37d000eb236609cf15aedd9e7a538927ea02c57b617908b6f237e9c", size = 4467, upload-time = "2025-07-08T06:54:40.396Z" }
 
 [[package]]
 name = "soupsieve"


### PR DESCRIPTION
## Summary

Promotes the infra-only change in #41 from `dev` to `main`. No other
changes are in `dev` beyond #41 itself.

What landed in #41 (all infra / CI, no product code):

- Pin all `mdformat` pre-commit `additional_dependencies` to exact
  versions; pin `shfmt-py==3.12.0.2` for a deterministic `shfmt` binary.
- Bump `codecov/codecov-action` v4.0.1 → v5.5.4, pin
  `codecov/test-results-action` v1 → v1.2.1,
  `tj-actions/changed-files` v46.0.5 → v47.0.6,
  `sigstore/gh-action-sigstore-python` v3.0.0 → v3.3.0.
- Fix coverage.xml emission (pytest was called with `--cov=src` but no
  `--cov-report=xml`, so `codecov-action` had nothing to upload).
- Fix the broken README tests badge link (`tests.yml` → `tests.yaml`).
- Add `pytest-rerunfailures==16.1` with a narrow `--only-rerun` pattern
  to auto-retry the e2e demo test when PhysioNet returns mid-stream
  `IncompleteRead` / `ChunkedEncodingError` (newly-flaky; unrelated
  upstream network issue, not a regression).

## Test plan

- [x] CI green on #41 → dev
- [ ] CI green on this PR → main