### PR TITLE
Sync dev into main: dependency version pinning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,9 +16,18 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]
+# Each dep is pinned with a lower bound at the version we actively test against,
+# and an upper bound at the next known-or-expected breaking major. `meds-extract`
+# is capped below 0.6 because that release ships breaking syntax changes that
+# require a coordinated code migration (tracked in #40).
 dependencies = [
-   "polars~=1.30.0", "meds-transforms~=0.6", "meds-extract~=0.5", "requests", "beautifulsoup4",
-   "hydra-core", "hydra-joblib-launcher",
+    "polars~=1.30",
+    "meds-transforms~=0.6",
+    "meds-extract~=0.5",
+    "requests~=2.32",
+    "beautifulsoup4~=4.12",
+    "hydra-core~=1.3",
+    "hydra-joblib-launcher~=1.2",
 ]
 
 [dependency-groups]
@@ -31,10 +40,10 @@ dependencies = [
 # reset / IncompleteRead mid-stream) instead of turning a bad upstream minute
 # into a failed CI build.
 dev = [
-    "pre-commit<4",
-    "ruff",
-    "pytest",
-    "pytest-cov",
+    "pre-commit~=3.8",
+    "ruff>=0.11,<1.0",
+    "pytest~=9.0",
+    "pytest-cov~=7.1",
     "pytest-rerunfailures==16.1",
     "shfmt-py==3.12.0.2",
 ]
@@ -42,7 +51,7 @@ dev = [
 [tool.setuptools_scm]
 
 [project.optional-dependencies]
-slurm_parallelism = ["hydra-submitit-launcher"]
+slurm_parallelism = ["hydra-submitit-launcher~=1.2"]
 
 [project.scripts]
 MEDS_extract-MIMIC_IV = "MIMIC_IV_MEDS.__main__:main"

--- a/uv.lock
+++ b/uv.lock
@@ -514,24 +514,24 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "beautifulsoup4" },
-    { name = "hydra-core" },
-    { name = "hydra-joblib-launcher" },
-    { name = "hydra-submitit-launcher", marker = "extra == 'slurm-parallelism'" },
+    { name = "beautifulsoup4", specifier = "~=4.12" },
+    { name = "hydra-core", specifier = "~=1.3" },
+    { name = "hydra-joblib-launcher", specifier = "~=1.2" },
+    { name = "hydra-submitit-launcher", marker = "extra == 'slurm-parallelism'", specifier = "~=1.2" },
     { name = "meds-extract", specifier = "~=0.5" },
     { name = "meds-transforms", specifier = "~=0.6" },
-    { name = "polars", specifier = "~=1.30.0" },
-    { name = "requests" },
+    { name = "polars", specifier = "~=1.30" },
+    { name = "requests", specifier = "~=2.32" },
 ]
 provides-extras = ["slurm-parallelism"]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "pre-commit", specifier = "<4" },
-    { name = "pytest" },
-    { name = "pytest-cov" },
+    { name = "pre-commit", specifier = "~=3.8" },
+    { name = "pytest", specifier = "~=9.0" },
+    { name = "pytest-cov", specifier = "~=7.1" },
     { name = "pytest-rerunfailures", specifier = "==16.1" },
-    { name = "ruff" },
+    { name = "ruff", specifier = ">=0.11,<1.0" },
     { name = "shfmt-py", specifier = "==3.12.0.2" },
 ]
 


### PR DESCRIPTION
Promotes #45 from \`dev\` to \`main\`. No other changes are in dev beyond that.

## What landed in #45

Added bounded version ranges to every runtime, optional, and dev dependency. No source or test code changes; \`uv.lock\` resolution is identical (each currently-installed version is still in-range). See #45 for the full table.

Closes #34.

## Test plan

- [x] CI green on #45 → dev
- [ ] CI green on this PR → main