### PR TITLE
Sync dev into main: download reliability fix (closes #42)

### DIFF
--- a/src/MIMIC_IV_MEDS/download.py
+++ b/src/MIMIC_IV_MEDS/download.py
@@ -107,6 +107,10 @@ class MockResponse:  # pragma: no cover
         return self
 
     def __exit__(self, exc_type, exc, tb):
+        # Mirror `requests.Response.__exit__`: close the response so the mock
+        # catches future regressions where production code starts relying on
+        # close being part of the context-manager contract.
+        self.close()
         return False
 
     def close(self):
@@ -127,6 +131,9 @@ class MockSession:  # pragma: no cover
         self.expect_url = expect_url
         self.headers = {}
         self.auth = None
+
+    def close(self):
+        pass
 
     def get(self, url: str, stream: bool = False, **kwargs):
         if self.expect_url is not None and url != self.expect_url:
@@ -399,17 +406,21 @@ def download_data(
 
     for url in urls:
         session = session_factory()
-
-        if isinstance(url, dict | DictConfig):
-            username = url.get("username", None)
-            password = url.get("password", None)
-            logger.info(f"Authenticating for {username}")
-            session.auth = (username, password)
-            session.headers.update({"User-Agent": "Wget/1.21.1 (linux-gnu)"})
-
-            url = url.url
-
         try:
-            crawl_and_download(url, output_dir, session)
-        except ValueError as e:
-            raise ValueError(f"Failed to download data from {url}") from e
+            if isinstance(url, dict | DictConfig):
+                username = url.get("username", None)
+                password = url.get("password", None)
+                logger.info(f"Authenticating for {username}")
+                session.auth = (username, password)
+                session.headers.update({"User-Agent": "Wget/1.21.1 (linux-gnu)"})
+
+                url = url.url
+
+            try:
+                crawl_and_download(url, output_dir, session)
+            except ValueError as e:
+                raise ValueError(f"Failed to download data from {url}") from e
+        finally:
+            # Release the connection pool tied to this per-URL session so
+            # long runs don't hold extra sockets/fds open after each URL.
+            session.close()

--- a/src/MIMIC_IV_MEDS/download.py
+++ b/src/MIMIC_IV_MEDS/download.py
@@ -28,9 +28,12 @@ DOWNLOAD_CHUNK_SIZE = 1024 * 1024
 def make_session_with_retries() -> requests.Session:
     """Return a `requests.Session` with a retry adapter mounted for transient server errors.
 
-    PhysioNet returns 429/502/503/504 regularly under load; without retries a single transient failure unwinds
-    the whole crawl. The adapter handles connect-time failures and error-status retries before the body starts
-    streaming. Backoff is exponential (2, 4, 8, 16, 32 s) and `Retry-After` headers are respected.
+    PhysioNet returns 429/500/502/503/504 regularly under load; without retries a single transient failure
+    unwinds the whole crawl. The adapter handles connect-time failures and error-status retries before the
+    body starts streaming. urllib3's first retry happens immediately; subsequent retries sleep
+    `backoff_factor * (2 ** (attempt - 1))` seconds, so with our `backoff_factor=2.0` and `total=5` the
+    worst-case sequence is 0, 2, 4, 8, 16 s between attempts (capped by urllib3's default `backoff_max`).
+    `Retry-After` headers are respected when the server supplies them.
     """
     session = requests.Session()
     retry = Retry(
@@ -99,6 +102,15 @@ class MockResponse:  # pragma: no cover
     def raise_for_status(self):
         if self.status_code != 200:
             raise requests.exceptions.HTTPError(self.status_code)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def close(self):
+        pass
 
 
 class MockSession:  # pragma: no cover
@@ -201,16 +213,21 @@ def download_file(url: str, output_dir: Path, session: requests.Session):
             )
 
     try:
-        response = session.get(url, stream=True, timeout=DEFAULT_TIMEOUT)
-        if response.status_code != 200:
-            logger.error(f"Failed to download {url} in streaming download_file get: {response.status_code}")
-        response.raise_for_status()
+        # Use the response as a context manager so a non-200 status (or any
+        # exception thrown by raise_for_status) reliably returns the streaming
+        # connection to the pool instead of leaking it.
+        with session.get(url, stream=True, timeout=DEFAULT_TIMEOUT) as response:
+            if response.status_code != 200:
+                logger.error(
+                    f"Failed to download {url} in streaming download_file get: {response.status_code}"
+                )
+            response.raise_for_status()
+            with open(file_path, "wb") as file:
+                for chunk in response.iter_content(chunk_size=DOWNLOAD_CHUNK_SIZE):
+                    file.write(chunk)
     except Exception as e:
         raise ValueError(f"Failed to download {url}") from e
 
-    with open(file_path, "wb") as file:
-        for chunk in response.iter_content(chunk_size=DOWNLOAD_CHUNK_SIZE):
-            file.write(chunk)
     logger.info(f"Downloaded: {file_path}")
 
 

--- a/src/MIMIC_IV_MEDS/download.py
+++ b/src/MIMIC_IV_MEDS/download.py
@@ -1,6 +1,7 @@
 import hashlib
 import logging
 import os
+from collections.abc import Callable
 from pathlib import Path
 from urllib.parse import urljoin, urlparse
 
@@ -314,7 +315,7 @@ def download_data(
     output_dir: Path,
     dataset_info: DictConfig,
     do_demo: bool = False,
-    session_factory: callable = make_session_with_retries,
+    session_factory: Callable[[], requests.Session] = make_session_with_retries,
 ):
     """Downloads the data specified in dataset_info.dataset_urls to the output_dir.
 
@@ -414,7 +415,10 @@ def download_data(
                 session.auth = (username, password)
                 session.headers.update({"User-Agent": "Wget/1.21.1 (linux-gnu)"})
 
-                url = url.url
+                # `.get("url")` works uniformly for both `dict` and
+                # `DictConfig`; attribute access `url.url` would have raised
+                # on a plain dict even though the isinstance check admits one.
+                url = url.get("url")
 
             try:
                 crawl_and_download(url, output_dir, session)

--- a/src/MIMIC_IV_MEDS/download.py
+++ b/src/MIMIC_IV_MEDS/download.py
@@ -7,6 +7,45 @@ from urllib.parse import urljoin, urlparse
 import requests
 from bs4 import BeautifulSoup
 from omegaconf import DictConfig
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
+
+# Connect and per-chunk read timeouts (seconds). `requests` defaults to no
+# timeout, so a stalled TCP socket parks a worker in recv() indefinitely —
+# PhysioNet's edge silently drops chunked connections, which was hitting us
+# as a full pipeline hang (see #42). READ_TIMEOUT_S is the gap between bytes,
+# not total wall-clock: a slow-but-alive 25 KB/s stream is fine, only truly
+# stalled connections trip it.
+CONNECT_TIMEOUT_S = 10.0
+READ_TIMEOUT_S = 60.0
+DEFAULT_TIMEOUT = (CONNECT_TIMEOUT_S, READ_TIMEOUT_S)
+
+# 1 MiB streaming chunks instead of 8 KiB — 128x fewer write() syscalls on
+# large files (chartevents.csv.gz is ~25 GB uncompressed) with no downside.
+DOWNLOAD_CHUNK_SIZE = 1024 * 1024
+
+
+def make_session_with_retries() -> requests.Session:
+    """Return a `requests.Session` with a retry adapter mounted for transient server errors.
+
+    PhysioNet returns 429/502/503/504 regularly under load; without retries a single transient failure unwinds
+    the whole crawl. The adapter handles connect-time failures and error-status retries before the body starts
+    streaming. Backoff is exponential (2, 4, 8, 16, 32 s) and `Retry-After` headers are respected.
+    """
+    session = requests.Session()
+    retry = Retry(
+        total=5,
+        backoff_factor=2.0,
+        status_forcelist=[429, 500, 502, 503, 504],
+        allowed_methods=frozenset(["GET", "HEAD"]),
+        respect_retry_after_header=True,
+        raise_on_status=False,
+    )
+    adapter = HTTPAdapter(max_retries=retry)
+    session.mount("http://", adapter)
+    session.mount("https://", adapter)
+    return session
+
 
 _checksum_cache = {}
 
@@ -29,7 +68,7 @@ def get_checksum_mapping(base_url: str, session: requests.Session) -> dict:
     if base_url in _checksum_cache:
         return _checksum_cache[base_url]
     checksum_url = base_url + "SHA256SUMS.txt" if base_url.endswith("/") else base_url + "/SHA256SUMS.txt"
-    r = session.get(checksum_url)
+    r = session.get(checksum_url, timeout=DEFAULT_TIMEOUT)
     r.raise_for_status()
     mapping = {}
     for line in r.text.strip().splitlines():
@@ -77,7 +116,7 @@ class MockSession:  # pragma: no cover
         self.headers = {}
         self.auth = None
 
-    def get(self, url: str, stream: bool = False):
+    def get(self, url: str, stream: bool = False, **kwargs):
         if self.expect_url is not None and url != self.expect_url:
             raise ValueError(f"Expected URL {self.expect_url}, got {url}")
         if isinstance(self.return_status, dict):
@@ -162,7 +201,7 @@ def download_file(url: str, output_dir: Path, session: requests.Session):
             )
 
     try:
-        response = session.get(url, stream=True)
+        response = session.get(url, stream=True, timeout=DEFAULT_TIMEOUT)
         if response.status_code != 200:
             logger.error(f"Failed to download {url} in streaming download_file get: {response.status_code}")
         response.raise_for_status()
@@ -170,7 +209,7 @@ def download_file(url: str, output_dir: Path, session: requests.Session):
         raise ValueError(f"Failed to download {url}") from e
 
     with open(file_path, "wb") as file:
-        for chunk in response.iter_content(chunk_size=8192):
+        for chunk in response.iter_content(chunk_size=DOWNLOAD_CHUNK_SIZE):
             file.write(chunk)
     logger.info(f"Downloaded: {file_path}")
 
@@ -222,7 +261,7 @@ def crawl_and_download(base_url: str, output_dir: Path, session: requests.Sessio
         return
 
     try:
-        response = session.get(base_url)
+        response = session.get(base_url, timeout=DEFAULT_TIMEOUT)
         if response.status_code != 200:
             logger.error(f"Failed to download {base_url} in initial get: {response.status_code}")
         response.raise_for_status()
@@ -251,7 +290,7 @@ def download_data(
     output_dir: Path,
     dataset_info: DictConfig,
     do_demo: bool = False,
-    session_factory: callable = requests.Session,
+    session_factory: callable = make_session_with_retries,
 ):
     """Downloads the data specified in dataset_info.dataset_urls to the output_dir.
 

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -7,7 +7,7 @@ import pytest
 from omegaconf import DictConfig
 
 from MIMIC_IV_MEDS import download as download_module
-from MIMIC_IV_MEDS.download import MockResponse, MockSession, download_data
+from MIMIC_IV_MEDS.download import MockResponse, MockSession, download_data, make_session_with_retries
 
 
 @pytest.fixture(autouse=True)
@@ -184,3 +184,17 @@ def test_redownload_on_checksum_mismatch(caplog, demo_only_config):
         assert demo_file.read_text() == correct_content
         redownloaded = any("Checksum mismatch for" in rec.message for rec in caplog.records)
         assert redownloaded, "Expected a checksum mismatch message prompting redownload."
+
+
+def test_make_session_with_retries_contract():
+    """Regression guard on the retry adapter config — catches silent changes to the retry policy."""
+    session = make_session_with_retries()
+    for prefix in ("http://", "https://"):
+        adapter = session.get_adapter(prefix + "example.com/")
+        retry = adapter.max_retries
+        assert retry.total == 5, f"total retries for {prefix}"
+        assert retry.backoff_factor == 2.0, f"backoff_factor for {prefix}"
+        assert set(retry.status_forcelist) == {429, 500, 502, 503, 504}, f"status_forcelist for {prefix}"
+        assert "GET" in retry.allowed_methods, f"GET in allowed_methods for {prefix}"
+        assert retry.respect_retry_after_header is True, f"respect_retry_after_header for {prefix}"
+        assert retry.raise_on_status is False, f"raise_on_status for {prefix}"

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -51,9 +51,9 @@ class TrackingMockSession(MockSession):
         super().__init__(*args, **kwargs)
         self.get_counts: dict[str, int] = {}
 
-    def get(self, url: str, stream: bool = False):
+    def get(self, url: str, stream: bool = False, **kwargs):
         self.get_counts[url] = self.get_counts.get(url, 0) + 1
-        return super().get(url, stream=stream)
+        return super().get(url, stream=stream, **kwargs)
 
 
 def test_skip_existing_download(caplog, dataset_config):
@@ -146,7 +146,7 @@ def test_redownload_on_checksum_mismatch(caplog, demo_only_config):
     ]
 
     class SwitchMockSession(TrackingMockSession):
-        def get(self, url: str, stream: bool = False):
+        def get(self, url: str, stream: bool = False, **kwargs):
             self.get_counts[url] = self.get_counts.get(url, 0) + 1
             current = responses[0]
             if url in current:


### PR DESCRIPTION
Promotes #44 from \`dev\` to \`main\`. The only content is the download-reliability bugfix.

## What landed

- **Timeouts on every \`session.get()\`** — \`timeout=(10, 60)\` on checksum fetch, file stream, and directory crawl. Fixes the indefinite hang from #42.
- **Session-level retry adapter** — \`urllib3.Retry(total=5, backoff_factor=2.0, status_forcelist=[429, 500, 502, 503, 504])\` on http + https. Single transient 502/503 no longer unwinds the crawl.
- **1 MiB streaming chunks** — 128× fewer \`file.write()\` syscalls on large files.
- **Connection-pool hygiene** — response is used as a context manager (no leak on \`raise_for_status()\` error paths); per-URL session is explicitly closed in a \`try/finally\`.
- **Type-annotation + dict-access correctness** — \`session_factory\` is now \`Callable[[], requests.Session]\`; \`url.get(\"url\")\` works for both \`dict\` and \`DictConfig\` (attribute access would have raised on a plain dict).
- **New contract test** — \`test_make_session_with_retries_contract\` pins down the retry policy so silent drift is caught by CI.

Closes #42.

## Test plan

- [x] CI green on #44 → dev
- [ ] CI green on this PR → main