### PR TITLE
fix: tighten meds-extract pin to actually cap below 0.6 (closes #53)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,11 +19,14 @@ classifiers = [
 # Each dep is pinned with a lower bound at the version we actively test against,
 # and an upper bound at the next known-or-expected breaking major. `meds-extract`
 # is capped below 0.6 because that release ships breaking syntax changes that
-# require a coordinated code migration (tracked in #40).
+# require a coordinated code migration (tracked in #40). The `~=0.5.0` form is
+# explicit about that: `~=0.5` would be `>=0.5,<1.0` per PEP 440, which lets
+# resolvers pick 0.6.x and silently break the MEDS extraction stage at runtime
+# with a parser error against the shipped `event_configs.yaml` (see #53).
 dependencies = [
     "polars~=1.30",
     "meds-transforms~=0.6",
-    "meds-extract~=0.5",
+    "meds-extract~=0.5.0",
     "requests~=2.32",
     "beautifulsoup4~=4.12",
     "hydra-core~=1.3",

--- a/uv.lock
+++ b/uv.lock
@@ -518,7 +518,7 @@ requires-dist = [
     { name = "hydra-core", specifier = "~=1.3" },
     { name = "hydra-joblib-launcher", specifier = "~=1.2" },
     { name = "hydra-submitit-launcher", marker = "extra == 'slurm-parallelism'", specifier = "~=1.2" },
-    { name = "meds-extract", specifier = "~=0.5" },
+    { name = "meds-extract", specifier = "~=0.5.0" },
     { name = "meds-transforms", specifier = "~=0.6" },
     { name = "polars", specifier = "~=1.30" },
     { name = "requests", specifier = "~=2.32" },


### PR DESCRIPTION
Closes #53

## Summary

Fix for #53. The `dependencies` block claims (in a comment) that `meds-extract` is "capped below 0.6 because that release ships breaking syntax changes." But the actual constraint `meds-extract~=0.5` is `>=0.5,<1.0` per PEP 440 — not `<0.6`. So `pip` / `uv` happily install `meds-extract==0.6.1` alongside `MIMIC-IV-MEDS==0.1.2`, and the pipeline blows up at runtime in the `convert_to_MEDS_events` stage with a parser error against the shipped `event_configs.yaml`.

I just hit this in a real end-to-end run after working around #51's PATH bug. Same long workflow, different rake.

## Change

```diff
-    "meds-extract~=0.5",
+    "meds-extract~=0.5.0",
```

`~=0.5.0` expands to `>=0.5.0,<0.6.0` — what the comment promises. Comment expanded to call out the PEP 440 gotcha so the next person maintaining this doesn't re-derive it.

## Why this is the right scope

- `meds-extract==0.5.0` natively handles list-form `code` fields (`if isinstance(code_field, str): code_field = [code_field]`) before calling the dftly parser — which matches the YAML format throughout the shipped `event_configs.yaml`.
- `meds-extract==0.6.x` switched to `str(code)` and hands the list `repr` (`"['MEDICATION', 'col(medication)', 'col(event_txt)']"`) to the parser, which can't grok it.
- The "real" fix (migrate the YAML to the new dftly f-string syntax + bump the lower bound to 0.6 once it's released with the parser change) is tracked in #40. This PR is the small "make today's released MIMIC-IV-MEDS actually installable + runnable" fix; it doesn't preempt that migration.

## Test plan

- [x] `uv pip install MIMIC-IV-MEDS==0.1.2` resolves to `meds-extract==0.5.0` (not 0.6.1).
- [x] End-to-end run: download + pre_MEDS + MEDS extraction stages clear without the parse error. Currently in progress; will update if anything else surfaces.
- No code changes; existing tests are unaffected.

## Notes

- I'm not adding a `dftly` pin in this PR even though `meds-extract==0.6.x` would otherwise pull in `dftly>=0.2.0` (which removed `extract_columns` and breaks 0.6.x's import). With `meds-extract==0.5.x` pinned here, that whole sub-tree is moot — 0.5.x doesn't import `extract_columns`. If 0.6.x ever gets re-admitted to the constraint (post-migration), a `dftly` pin should be added at that time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
