### PR TITLE
fix: auto-convert large CSVs to parquet; unconditionally fetch metadata

### DIFF
--- a/src/MIMIC_IV_MEDS/__main__.py
+++ b/src/MIMIC_IV_MEDS/__main__.py
@@ -85,6 +85,17 @@ def main(cfg: DictConfig):
     else:  # pragma: no cover
         logger.info("Skipping data download.")
 
+    # Always fetch concept-map metadata CSVs — they're small (~100 KB each),
+    # hosted on GitHub (no PhysioNet auth required), and unconditionally
+    # needed by the extract_code_metadata stage regardless of do_download.
+    from .download import download_file, make_session_with_retries
+
+    for url in dataset_info.urls.get("common", []):
+        try:
+            download_file(url, raw_input_dir, make_session_with_retries())
+        except Exception as e:
+            logger.warning(f"Failed to download metadata file {url}: {e}")
+
     # Step 1: Pre-MEDS Data Wrangling
     if HAS_PRE_MEDS:
         pre_MEDS_transform(

--- a/src/MIMIC_IV_MEDS/pre_MEDS.py
+++ b/src/MIMIC_IV_MEDS/pre_MEDS.py
@@ -13,6 +13,12 @@ from MEDS_transforms.dataframe import write_df
 
 logger = logging.getLogger(__name__)
 
+# Files above this threshold (in bytes) are auto-converted from CSV to parquet
+# using polars streaming to avoid OOM during CSV loading in downstream stages.
+# This is particularly important for modules like chartevents (~3.3 GB) and
+# labevents (~2.4 GB) which can exceed available memory with eager CSV loading.
+LARGE_CSV_SIZE_THRESHOLD = 500_000_000
+
 
 def add_dot(code: pl.Expr, position: int) -> pl.Expr:
     """Adds a dot to the code expression at the specified position.
@@ -318,6 +324,23 @@ def main(
         out_fp.parent.mkdir(parents=True, exist_ok=True)
 
         if pfx not in FUNCTIONS and pfx not in [p for p, _ in ICD_DFS_TO_FIX]:
+            file_size = fp.stat().st_size
+            large_csv = (
+                (fp.suffix == ".csv" or fp.name.endswith(".csv.gz"))
+                and file_size > LARGE_CSV_SIZE_THRESHOLD
+            )
+            if large_csv:
+                out_fp = output_dir / f"{pfx}.parquet"
+                if out_fp.is_file():
+                    print(f"Done with {pfx}. Continuing")
+                    continue
+                logger.info(
+                    f"Converting large CSV {pfx} ({file_size / 1e6:.0f} MB) to parquet via streaming..."
+                )
+                st = datetime.now()
+                pl.scan_csv(fp, infer_schema_length=100000).sink_parquet(out_fp)
+                logger.info(f"  Converted to parquet in {datetime.now() - st}")
+                continue
             if do_copy:
                 logger.info(f"No function needed for {pfx}: Copying {fp.resolve()!s} to {out_fp.resolve()!s}")
                 shutil.copy(fp, out_fp)


### PR DESCRIPTION
Two linked fixes for running with `do_download=False` on memory-constrained hardware (closes #55):

### 1. Auto-parquet conversion for large CSVs (`pre_MEDS.py`)

CSV files >500 MB are auto-converted to parquet via polars streaming (`pl.scan_csv` -> `sink_parquet`) during the pre-MEDS stage instead of being copied/symlinked as-is. This eliminates the OOM in `shard_events` when `chartevents.csv.gz` (~3.3 GB) or `labevents.csv.gz` (~2.4 GB) are loaded eagerly into memory.

Key design choices:
- **No new config flags** — threshold-based (500 MB), zero-config change
- **Streaming throughout** — `pl.scan_csv` on `.gz` files streams decompression; `sink_parquet` writes without materializing the full frame
- **Zero-dependency** — `polars` is already a project dependency
- **Non-breaking** — downstream stages already prefer `.parquet` over `.csv.gz` via `get_supported_fp`; output dir only ever has one format per prefix
- **Tested on M4 Pro (24 GB RAM)** — full pipeline completes in ~40 min

### 2. Unconditional metadata download (`__main__.py`)

The 10 concept-map metadata CSVs (hosted on GitHub, no PhysioNet auth required) are now downloaded unconditionally instead of only when `do_download=True`. Previously, running with `do_download=False` (e.g. data already present) would skip these small files, causing `extract_code_metadata` to fail.


- [x] Tests pass (19/21; 2 e2e failures are pre-existing — `MEDS_extract-MIMIC_IV` not on PATH)
- [x] Demo pipeline verified end-to-end
- [x] Full MIMIC-IV v3.1 pipeline verified end-to-end