### PR TITLE
ci: broaden flaky-download rerun allowlist to timeout-class failures

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -28,18 +28,20 @@ jobs:
 
       - name: Run tests
         # `--reruns`/`--only-rerun` (from pytest-rerunfailures) retries the
-        # e2e demo-download test when PhysioNet returns mid-stream connection
-        # errors (IncompleteRead / ChunkedEncodingError / ConnectionError).
-        # These are upstream transient failures, not real regressions, and
+        # e2e demo-download test when PhysioNet returns transient network
+        # errors. These are upstream failures, not real regressions, and
         # blocking CI on them means no PR can land during a bad PhysioNet
-        # minute. The pattern is intentionally narrow: anything else fails
-        # hard on first occurrence.
+        # minute. The pattern is intentionally scoped to network-shaped
+        # failures: anything else fails hard on first occurrence.
+        # ConnectTimeout/ReadTimeout/MaxRetryError cover requests/urllib3
+        # timeout paths (surfaced as ConnectTimeoutError, not ConnectionError),
+        # and `[Cc]onnection broken` matches urllib3's lowercase message.
         run: |
           uv run pytest src/ tests/ -v --doctest-modules \
             --cov=src --cov-report=xml --cov-report=term \
             --junitxml=junit.xml -s \
             --reruns 3 --reruns-delay 20 \
-            --only-rerun "IncompleteRead|ChunkedEncodingError|ConnectionError|Connection broken"
+            --only-rerun "IncompleteRead|ChunkedEncodingError|ConnectionError|ConnectTimeout|ReadTimeout|MaxRetryError|[Cc]onnection broken"
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5.5.4


### PR DESCRIPTION
## Summary

PR #52's CI was killed by a transient PhysioNet outage (2026-04-25, ~18:40–18:52 UTC): the demo download died with `urllib3 ConnectTimeoutError` after exhausting in-process retries, and the pytest-rerunfailures safety net never fired because the `--only-rerun` allowlist doesn't match timeout-class failures:

- `ConnectTimeout`/`ConnectTimeoutError` are not `ConnectionError` (different exception family in requests/urllib3), and
- `Connection broken` never matches — urllib3 logs it lowercase (`connection broken by ...`) and the pattern is case-sensitive.

This broadens the allowlist to `IncompleteRead|ChunkedEncodingError|ConnectionError|ConnectTimeout|ReadTimeout|MaxRetryError|[Cc]onnection broken`, so timeout-shaped transient failures retry the same way mid-stream failures already do. Non-network failures still fail hard on first occurrence.

Refs #42 (where the retry machinery was introduced).

🤖 Generated with [Claude Code](https://claude.com/claude-code)