### PR TITLE
Sync dev into main: activation-equivalent console-script resolution

### DIFF
--- a/src/MIMIC_IV_MEDS/commands.py
+++ b/src/MIMIC_IV_MEDS/commands.py
@@ -3,59 +3,104 @@ import os
 import shutil
 import subprocess
 import sys
-from pathlib import Path
+import sysconfig
 
 logger = logging.getLogger(__name__)
 
 
-def resolve_console_script(name: str) -> str:
-    """Locate a console script that pip / uv installed alongside the running Python.
+def activation_equivalent_path(path: str | None = None, *, scripts_dir: str | None = None) -> str:
+    """Returns ``PATH`` with this environment's scripts directory prepended.
 
-    `subprocess.run([name, ...])` does a `PATH` lookup. When the user runs the bundled
-    `MEDS_extract-MIMIC_IV` directly via its venv path (without first activating the
-    venv), the venv's `bin/` is not on `PATH`, and `subprocess` raises
-    `FileNotFoundError` even though the script is installed in the same venv as the
-    Python interpreter that's calling it. Looking next to `sys.executable` first
-    sidesteps the PATH coupling — that's where pip / uv guarantee console scripts land.
+    Prepending the environment's scripts directory (``sysconfig.get_path("scripts")`` —
+    the venv's ``bin/``, or ``Scripts\\`` on Windows) is exactly what ``source
+    .../activate`` does to ``PATH``. Building that same view explicitly means
+    subprocesses resolve console scripts identically whether or not the caller
+    activated the environment, without inventing any resolution order beyond the
+    standard, documented one.
+
+    Args:
+        path: The ``PATH`` value to prepend to. Defaults to ``os.environ["PATH"]``.
+        scripts_dir: Override of the scripts directory (for tests). Defaults to
+            ``sysconfig.get_path("scripts")``.
+
+    Returns:
+        ``scripts_dir`` followed by the entries of ``path``, minus any duplicate
+        occurrence of ``scripts_dir`` and any empty entries (a leading/trailing
+        separator would otherwise mean "current directory" on POSIX).
+
+    Examples:
+        >>> activation_equivalent_path("/usr/bin", scripts_dir="/my/venv/bin")
+        '/my/venv/bin:/usr/bin'
+
+        Idempotent — an already-activated ``PATH`` is not double-prepended:
+
+        >>> activation_equivalent_path("/my/venv/bin:/usr/bin", scripts_dir="/my/venv/bin")
+        '/my/venv/bin:/usr/bin'
+
+        An empty ``PATH`` yields just the scripts directory:
+
+        >>> activation_equivalent_path("", scripts_dir="/my/venv/bin")
+        '/my/venv/bin'
+    """
+    if path is None:
+        path = os.environ.get("PATH", "")
+    if scripts_dir is None:
+        scripts_dir = sysconfig.get_path("scripts")
+    parts = [p for p in path.split(os.pathsep) if p and p != scripts_dir]
+    return os.pathsep.join([scripts_dir, *parts])
+
+
+def resolve_console_script(name: str, *, scripts_dir: str | None = None) -> str:
+    """Resolves console script ``name`` exactly as an activated environment would.
+
+    ``subprocess.run([name, ...])`` resolves via the ambient ``PATH``, which omits this
+    environment's scripts directory unless the user activated the venv — so running the
+    bundled ``MEDS_extract-MIMIC_IV`` by its venv path (cron jobs, Slurm scripts,
+    Makefiles) previously died with ``FileNotFoundError`` on this subprocess even
+    though the script was installed right beside the interpreter (#51). Resolving with
+    ``shutil.which`` against the activation-equivalent ``PATH`` gives the same result
+    activation would, with real executable semantics (exec-bit checks on POSIX,
+    ``PATHEXT`` on Windows) rather than bespoke file probing.
 
     Args:
         name: The console script's basename (e.g. ``"MEDS_transform-pipeline"``).
+        scripts_dir: Override of the scripts directory (for tests).
 
     Returns:
         Absolute path to the executable.
 
     Raises:
-        FileNotFoundError: If the script is neither next to `sys.executable` nor on PATH.
+        FileNotFoundError: If the script is neither in the scripts directory nor on
+            ``PATH``.
 
     Examples:
-        Found next to `sys.executable` — works without an activated venv:
+        Console scripts installed in this environment resolve without activation:
 
-        >>> import sys
-        >>> resolve_console_script(Path(sys.executable).name)  # the python itself
-        ... # doctest: +ELLIPSIS
-        '...'
+        >>> from pathlib import Path
+        >>> import sysconfig
+        >>> exe = resolve_console_script("MEDS_transform-pipeline")
+        >>> Path(exe).parent == Path(sysconfig.get_path("scripts"))
+        True
 
-        Falls back to PATH for tools installed elsewhere (e.g. via `apt`):
+        Tools installed elsewhere still resolve through the ambient ``PATH``:
 
         >>> resolve_console_script("ls")  # doctest: +ELLIPSIS
         '/.../ls'
 
-        Missing scripts raise with a useful message that names the lookup it tried:
+        Missing scripts raise with a message naming both lookup locations:
 
         >>> resolve_console_script("definitely-not-a-real-script-xyz")
         Traceback (most recent call last):
             ...
-        FileNotFoundError: 'definitely-not-a-real-script-xyz' not found next to ... or on PATH...
+        FileNotFoundError: 'definitely-not-a-real-script-xyz' not found in this environment's scripts...
     """
-    candidate = Path(sys.executable).parent / name
-    if candidate.is_file():
-        return str(candidate)
-    found = shutil.which(name)
+    found = shutil.which(name, path=activation_equivalent_path(scripts_dir=scripts_dir))
     if found:
         return found
     raise FileNotFoundError(
-        f"{name!r} not found next to {sys.executable} or on PATH. "
-        f"Reinstall the package that provides it in this environment."
+        f"{name!r} not found in this environment's scripts directory "
+        f"({scripts_dir or sysconfig.get_path('scripts')}) or on PATH. "
+        f"Reinstall the package that provides it in this environment ({sys.executable})."
     )
 
 
@@ -65,6 +110,10 @@ def run_command(
     runner_fn: callable = subprocess.run,
 ):
     """Runs a command with the specified runner function.
+
+    The child's ``PATH`` is upgraded to the activation-equivalent view (see
+    :func:`activation_equivalent_path`), so any console scripts the child spawns in
+    turn resolve the same way ours do — activated or not.
 
     Args:
         command_parts: A list of the arguments to be run without shell interpretation.
@@ -90,6 +139,7 @@ def run_command(
     """
     logger.info(f"Running command: {command_parts}")
     run_env = {**os.environ, **(env or {})}
+    run_env["PATH"] = activation_equivalent_path(run_env.get("PATH", ""))
     command_out = runner_fn(command_parts, capture_output=True, env=run_env)
 
     # https://stackoverflow.com/questions/21953835/run-subprocess-and-print-output-to-logging

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,24 +1,25 @@
 """Tests for `MIMIC_IV_MEDS.commands`.
 
-Coverage focuses on `resolve_console_script` — the helper added to fix the case where
-the bundled `MEDS_extract-MIMIC_IV` is run from a venv that hasn't been activated, and
-the subprocess can't find `MEDS_transform-pipeline` because PATH doesn't include the
-venv's `bin/`. Doctests in `commands.py` cover the happy path and the missing-script
-error message; this file pins the cross-cutting behaviors (PATH-vs-sys.executable
-resolution order, env-var inheritance) that a future refactor might silently break.
+Coverage focuses on `resolve_console_script` and `activation_equivalent_path` — the
+helpers that make subprocess console-script resolution behave exactly as if the
+environment were activated, fixing the unactivated-venv invocation failure (#51)
+without any bespoke resolution order. Doctests in `commands.py` cover the happy path
+and the missing-script error; this file pins the cross-cutting behaviors (activation
+precedence, PATH fallback, executable semantics, child-PATH propagation) that a future
+refactor might silently break.
 """
 
 from __future__ import annotations
 
 import os
-import shutil
 import stat
-import sys
+import subprocess
+import sysconfig
 from pathlib import Path
 
 import pytest
 
-from MIMIC_IV_MEDS.commands import resolve_console_script
+from MIMIC_IV_MEDS.commands import activation_equivalent_path, resolve_console_script, run_command
 
 
 def _make_executable(path: Path) -> None:
@@ -26,103 +27,120 @@ def _make_executable(path: Path) -> None:
     path.chmod(path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
 
 
-def test_resolve_console_script_prefers_sys_executable_dir(tmp_path, monkeypatch):
-    """When the script exists next to sys.executable, that path wins over PATH — this is the whole point of
-    the helper, since PATH might not include the venv."""
-    fake_venv_bin = tmp_path / "venv" / "bin"
-    fake_venv_bin.mkdir(parents=True)
-    fake_python = fake_venv_bin / "python"
-    _make_executable(fake_python)
-    fake_script = fake_venv_bin / "my-script"
-    _make_executable(fake_script)
+def test_scripts_dir_wins_over_path(tmp_path, monkeypatch):
+    """The environment's scripts dir takes precedence over ambient PATH — exactly the precedence `source
+    .../activate` would give, since activation prepends that dir."""
+    scripts = tmp_path / "venv" / "bin"
+    scripts.mkdir(parents=True)
+    venv_script = scripts / "my-script"
+    _make_executable(venv_script)
 
-    # And put a *different* my-script earlier on PATH — if the helper ever reverts to
-    # a PATH-first lookup, this test catches it.
     other_dir = tmp_path / "other"
     other_dir.mkdir()
-    other_script = other_dir / "my-script"
-    _make_executable(other_script)
+    _make_executable(other_dir / "my-script")
 
-    monkeypatch.setattr(sys, "executable", str(fake_python))
     monkeypatch.setenv("PATH", f"{other_dir}{os.pathsep}/usr/bin")
 
-    resolved = resolve_console_script("my-script")
-    assert resolved == str(fake_script), f"expected {fake_script} (next to sys.executable), got {resolved}"
+    resolved = resolve_console_script("my-script", scripts_dir=str(scripts))
+    assert resolved == str(venv_script), f"expected {venv_script} (activation precedence), got {resolved}"
 
 
-def test_resolve_console_script_falls_back_to_path(tmp_path, monkeypatch):
-    """When no sibling script exists, fall back to PATH lookup."""
-    fake_venv_bin = tmp_path / "venv" / "bin"
-    fake_venv_bin.mkdir(parents=True)
-    fake_python = fake_venv_bin / "python"
-    _make_executable(fake_python)
-    # Note: NO my-script next to fake_python.
+def test_falls_back_to_ambient_path(tmp_path, monkeypatch):
+    """Tools not installed in this environment still resolve through the ambient PATH."""
+    scripts = tmp_path / "venv" / "bin"
+    scripts.mkdir(parents=True)  # NOTE: no my-script here
 
     other_dir = tmp_path / "other"
     other_dir.mkdir()
     other_script = other_dir / "my-script"
     _make_executable(other_script)
 
-    monkeypatch.setattr(sys, "executable", str(fake_python))
     monkeypatch.setenv("PATH", f"{other_dir}{os.pathsep}/usr/bin")
 
-    resolved = resolve_console_script("my-script")
+    resolved = resolve_console_script("my-script", scripts_dir=str(scripts))
     assert resolved == str(other_script), f"expected PATH fallback to {other_script}, got {resolved}"
 
 
-def test_resolve_console_script_raises_when_not_found(tmp_path, monkeypatch):
-    """Useful error when the script genuinely isn't installed — surfaces both lookup locations so the user
-    knows what to check."""
-    fake_venv_bin = tmp_path / "venv" / "bin"
-    fake_venv_bin.mkdir(parents=True)
-    fake_python = fake_venv_bin / "python"
-    _make_executable(fake_python)
+def test_raises_when_not_found(tmp_path, monkeypatch):
+    """Useful error when the script genuinely isn't installed — names both lookup locations so the user knows
+    what to check."""
+    scripts = tmp_path / "venv" / "bin"
+    scripts.mkdir(parents=True)
 
-    monkeypatch.setattr(sys, "executable", str(fake_python))
-    monkeypatch.setenv("PATH", "")  # nothing on PATH
+    monkeypatch.setenv("PATH", "")
 
-    with pytest.raises(FileNotFoundError, match=r"not found next to .* or on PATH"):
-        resolve_console_script("definitely-not-installed-xyz-script")
+    with pytest.raises(FileNotFoundError, match=r"not found in this environment's scripts"):
+        resolve_console_script("definitely-not-installed-xyz-script", scripts_dir=str(scripts))
 
 
-def test_resolve_console_script_actually_finds_real_console_script():
-    """Self-check: the package's own MEDS_transform-pipeline (installed alongside us
-    via the test extras) must resolve via the sys.executable path. If this fails, the
-    test environment is broken — and so is real-world usage."""
-    resolved = resolve_console_script("MEDS_transform-pipeline")
-    assert Path(resolved).is_file(), f"resolved to {resolved} which doesn't exist"
-    # It must be the one in OUR venv (next to sys.executable), not some random PATH hit.
-    expected_dir = Path(sys.executable).parent
-    assert Path(resolved).parent == expected_dir, (
-        f"resolved {resolved} but sys.executable dir is {expected_dir} — "
-        f"the sys.executable-first lookup didn't fire"
-    )
-
-
-def test_resolve_console_script_skips_directories_named_like_scripts(tmp_path, monkeypatch):
-    """A directory next to sys.executable that happens to share the script name should not satisfy the lookup
-    — `is_file()` rules it out and we fall through to PATH."""
-    fake_venv_bin = tmp_path / "venv" / "bin"
-    fake_venv_bin.mkdir(parents=True)
-    fake_python = fake_venv_bin / "python"
-    _make_executable(fake_python)
-    # A *directory* with the script's name next to python — NOT a real executable.
-    (fake_venv_bin / "my-script").mkdir()
+def test_directory_named_like_script_is_skipped(tmp_path, monkeypatch):
+    """A directory in the scripts dir sharing the script's name must not satisfy the lookup — `shutil.which`
+    applies real executable semantics."""
+    scripts = tmp_path / "venv" / "bin"
+    scripts.mkdir(parents=True)
+    (scripts / "my-script").mkdir()  # a directory, not an executable
 
     other_dir = tmp_path / "other"
     other_dir.mkdir()
     other_script = other_dir / "my-script"
     _make_executable(other_script)
 
-    monkeypatch.setattr(sys, "executable", str(fake_python))
     monkeypatch.setenv("PATH", f"{other_dir}{os.pathsep}/usr/bin")
 
-    resolved = resolve_console_script("my-script")
-    assert resolved == str(other_script), (
-        f"expected fallback to {other_script} (the dir-named-my-script next to "
-        f"sys.executable should not have matched), got {resolved}"
+    resolved = resolve_console_script("my-script", scripts_dir=str(scripts))
+    assert resolved == str(other_script)
+
+
+def test_non_executable_file_is_skipped(tmp_path, monkeypatch):
+    """A plain (non-executable) file in the scripts dir must not shadow a real executable on PATH —
+    `shutil.which` checks the exec bit, unlike a bare `is_file()` probe."""
+    scripts = tmp_path / "venv" / "bin"
+    scripts.mkdir(parents=True)
+    (scripts / "my-script").write_text("not executable")
+
+    other_dir = tmp_path / "other"
+    other_dir.mkdir()
+    other_script = other_dir / "my-script"
+    _make_executable(other_script)
+
+    monkeypatch.setenv("PATH", f"{other_dir}{os.pathsep}/usr/bin")
+
+    resolved = resolve_console_script("my-script", scripts_dir=str(scripts))
+    assert resolved == str(other_script)
+
+
+def test_resolves_real_console_script_without_activation_precedence_leaks():
+    """Self-check: the package's own MEDS_transform-pipeline (installed alongside us)
+    must resolve into this environment's scripts directory. If this fails, the test
+    environment is broken — and so is real-world usage."""
+    resolved = resolve_console_script("MEDS_transform-pipeline")
+    assert Path(resolved).is_file(), f"resolved to {resolved} which doesn't exist"
+    assert Path(resolved).parent == Path(sysconfig.get_path("scripts")), (
+        f"resolved {resolved} but this environment's scripts dir is "
+        f"{sysconfig.get_path('scripts')} — activation-equivalent precedence didn't fire"
     )
 
 
-# Suppress "unused" warnings for the imports we keep for visibility above.
-_ = shutil
+def test_run_command_child_path_is_activation_equivalent(monkeypatch):
+    """The child process must see the activation-equivalent PATH so that console scripts *it* spawns resolve
+    the same way ours do."""
+    seen = {}
+
+    def capture_runner(cmd, capture_output, env):
+        seen["env"] = env
+        return subprocess.CompletedProcess(args=cmd, returncode=0, stdout=b"", stderr=b"")
+
+    monkeypatch.setenv("PATH", "/usr/bin")
+    run_command(["echo", "hello"], runner_fn=capture_runner)
+
+    child_path = seen["env"]["PATH"].split(os.pathsep)
+    assert child_path[0] == sysconfig.get_path("scripts")
+    assert "/usr/bin" in child_path
+
+
+def test_activation_equivalent_path_never_emits_empty_entries():
+    """Empty PATH entries mean "current directory" on POSIX; the helper must never introduce one, whatever the
+    input shape."""
+    for raw in ("", ":", "/usr/bin:", ":/usr/bin", "/usr/bin::/bin"):
+        result = activation_equivalent_path(raw, scripts_dir="/my/venv/bin")
+        assert "" not in result.split(os.pathsep), f"empty entry leaked from input {raw!r}: {result}"


### PR DESCRIPTION
## Summary

Rolls up exactly one merged `dev` PR into `main` — #62, which replaces #52's sibling-file console-script probing with resolution against an activation-equivalent `PATH` (the environment's `sysconfig.get_path("scripts")` prepended — precisely what `source .../activate` does), via `shutil.which` for real executable semantics.

Beyond fixing #52's shadowing/exec-bit warts, this is the *complete* fix for the #51 failure class: `run_command` now hands the child the same activation-equivalent `PATH`, so `MEDS_transform-pipeline`'s own internal bare-name spawn of `MEDS_transform-stage` (per stage, `shell=True` — see mmcdermott/MEDS_transforms#398) resolves correctly too. First-hop-only resolution — including #52 as shipped on `main` — would still die one hop deeper in a genuinely unactivated environment; this makes `main` fully correct for that scenario.

Refs #51, #52, #62.

🤖 Generated with [Claude Code](https://claude.com/claude-code)