### PR TITLE
compat: make every released version buildable again (pins only, no ETL changes)

### DIFF
--- a/compat/README.md
+++ b/compat/README.md
@@ -1,0 +1,69 @@
+# Building released versions that no longer install
+
+Seven of this ETL's ten released versions do not install into a working pipeline today. In
+every case the released **code is fine** — only the upstream version specifier is wrong, so a
+resolver run now picks a MEDS-Transforms or MEDS-Extract release years newer than the one the
+version was written against.
+
+This directory records the upstream that actually works for each release, so any published
+version can still be rebuilt, run, and audited.
+
+```bash
+compat/build_version.sh 0.1.2 /tmp/mimic-0.1.2
+PATH="/tmp/mimic-0.1.2/.venv/bin:$PATH" \
+  /tmp/mimic-0.1.2/.venv/bin/MEDS_extract-MIMIC_IV root_output_dir=$OUT do_demo=True
+```
+
+## What was wrong, per version
+
+| version | declared | resolves to | failure | works with |
+|---|---|---|---|---|
+| 0.0.1 | `meds-transforms` | 0.6.7 | `ModuleNotFoundError: MEDS_transforms.extract` | `==0.0.9` |
+| 0.0.2 | `meds-transforms` | 0.6.7 | same | `==0.0.9` |
+| 0.0.3 | `meds-transforms>=0.1` | 0.6.7 | same | `==0.1` |
+| 0.0.4 | `meds-transforms~=0.2` | 0.6.7 | same | `==0.2.1` |
+| 0.0.5 | `meds-transforms~=0.2.1` | 0.2.4 | ✅ installs and runs | *(pinned for exactness)* |
+| 0.0.6 | `meds-transforms~=0.2.1` | 0.2.4 | ✅ | *(pinned for exactness)* |
+| 0.0.7 | `meds-transforms~=0.2.1` | 0.2.4 | ✅ | *(pinned for exactness)* |
+| 0.1.0 | `meds-extract~=0.5` | 0.6.2 | `Failed to parse expression "['HCPCS', 'col(short_description)']"` | `meds-extract==0.5.0` |
+| 0.1.1 | `meds-extract~=0.5` | 0.6.2 | same | `meds-extract==0.5.0` |
+| 0.1.2 | `meds-extract~=0.5` | 0.6.2 | same | `meds-extract==0.5.0` |
+
+Two distinct breakages:
+
+- **0.0.1–0.0.4** — extraction moved out of MEDS-Transforms into MEDS-Extract, so
+  `MEDS_transforms.extract` disappeared. Any unbounded `meds-transforms` requirement walks
+  straight into it.
+- **0.1.0–0.1.2** — MEDS-Extract 0.6 routes code specifications through dftly's expression
+  parser, which rejects the YAML list form (`[HCPCS, col(short_description)]`) that these
+  configs use. Verified that 0.6.1 fails identically to 0.6.2, so the boundary is 0.5 → 0.6,
+  not a 0.6.2 regression.
+
+`~=0.2.1` (in 0.0.5–0.0.7) is the only specifier in this ETL's history that means what its
+author intended: `>=0.2.1,<0.3`. **`~=0.2` and `~=0.5` both admit the next minor**, and both
+MEDS-Transforms and MEDS-Extract make breaking changes across minors while pre-1.0.
+
+## Why this is a branch and not a fix on `main`
+
+The right *forward* fix is to cap the upstream at the next minor, and `main` has already moved
+far past these releases — it is mid-migration to MEDS-Extract 0.7, where the ETL is pure
+config. Retro-fitting `main` would not help anyone trying to rebuild 0.0.3.
+
+Fixing this properly for consumers would mean publishing patch releases of each line
+(`0.1.3` with `meds-extract>=0.5,<0.6`, and so on) or yanking the versions that cannot be
+installed correctly. That is a maintainer decision. Until then, this directory is the
+executable record of how to get each one running, and it costs `main` nothing.
+
+## How these were verified
+
+Each version was installed into an isolated venv from PyPI with its constraints file, then run
+against a **single cached copy** of the PhysioNet `mimic-iv-demo/2.2` release with downloading
+disabled — byte-identical input for every version, so any difference in output is attributable
+to the ETL rather than to a re-download.
+
+All ten produce a valid MEDS cohort. Their summary-stats fingerprints are near-identical: the
+only movement in the entire published history is a deliberate expansion at 0.0.7 → 0.1.0
+(events 83,419 → 96,949). Every version also stamps `dataset_version: "3.1:<etl>"` onto a
+cohort built from the **2.2** demo release — a mislabelling fixed only on the 0.7 branch.
+
+See [issue #66](https://github.com/Medical-Event-Data-Standard/MIMIC_IV_MEDS/issues/66).

--- a/compat/build_version.sh
+++ b/compat/build_version.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Build a working environment for a *released* version of this ETL.
+#
+#   compat/build_version.sh <version> [target_dir]
+#
+# e.g. compat/build_version.sh 0.1.2 /tmp/mimic-0.1.2
+#      /tmp/mimic-0.1.2/.venv/bin/MEDS_extract-MIMIC_IV root_output_dir=$OUT do_demo=True
+#
+# Why this exists: seven of the ten released versions no longer install into a working ETL,
+# because their upstream specifier is unbounded and today's resolver picks a release years
+# newer than the one the version was written against. The ETL code in those releases is fine.
+# `compat/constraints/<version>.txt` records the upstream that actually works, so a published
+# version can still be rebuilt and audited.
+#
+# This script deliberately installs the released artifact from PyPI, NOT the working tree --
+# the point is to reproduce what was published.
+set -euo pipefail
+
+VERSION="${1:-}"
+TARGET="${2:-}"
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if [[ -z $VERSION ]]; then
+    echo "usage: $0 <version> [target_dir]" >&2
+    echo >&2
+    echo "available:" >&2
+    for f in "$HERE"/constraints/*.txt; do
+        b="$(basename "$f" .txt)"
+        echo "  $b  -- $(grep -m1 -oE '^[a-z-]+==[0-9.]+' "$f")" >&2
+    done
+    exit 2
+fi
+
+CONSTRAINTS="$HERE/constraints/$VERSION.txt"
+if [[ ! -f $CONSTRAINTS ]]; then
+    echo "ERROR: no constraints recorded for version '$VERSION'" >&2
+    echo "       known: $(cd "$HERE/constraints" && ls *.txt | sed 's/\.txt//' | tr '\n' ' ')" >&2
+    exit 2
+fi
+
+TARGET="${TARGET:-$(mktemp -d -t "mimic-iv-meds-$VERSION-XXXX")}"
+mkdir -p "$TARGET"
+
+if ! command -v uv >/dev/null 2>&1; then
+    echo "ERROR: uv is required (https://docs.astral.sh/uv/)" >&2
+    exit 1
+fi
+
+echo "Building MIMIC-IV-MEDS $VERSION in $TARGET"
+# 3.12 first, 3.11 as a fallback: the oldest releases predate 3.12 wheels for parts of their
+# numeric stack.
+for py in 3.12 3.11; do
+    rm -rf "$TARGET/.venv"
+    uv venv --python "$py" "$TARGET/.venv" >/dev/null 2>&1 || continue
+    if VIRTUAL_ENV="$TARGET/.venv" uv pip install \
+        "MIMIC-IV-MEDS==$VERSION" -c "$CONSTRAINTS" >"$TARGET/build.log" 2>&1; then
+        echo "  installed on Python $py"
+        VIRTUAL_ENV="$TARGET/.venv" uv pip freeze >"$TARGET/requirements.frozen.txt"
+        echo "  frozen closure -> $TARGET/requirements.frozen.txt"
+        echo
+        echo "Run the demo with:"
+        echo "  PATH=\"$TARGET/.venv/bin:\$PATH\" \\"
+        echo "    $TARGET/.venv/bin/MEDS_extract-MIMIC_IV root_output_dir=\$OUT do_demo=True"
+        echo
+        echo "(PATH matters: the ETL shells out to MEDS_transform-pipeline by bare name.)"
+        exit 0
+    fi
+done
+
+echo "ERROR: install failed on both 3.12 and 3.11; see $TARGET/build.log" >&2
+exit 1

--- a/compat/constraints/0.0.1.txt
+++ b/compat/constraints/0.0.1.txt
@@ -1,0 +1,8 @@
+# Constraints that make MIMIC-IV-MEDS 0.0.1 run again.
+#
+# Why: declares bare 'meds-transforms' (unbounded); today resolves 0.6.7, where MEDS_transforms.extract no longer exists
+#
+# Verified 2026-08-05 by building the MIMIC-IV demo cohort end to end on Python 3.12.
+# Usage:
+#   uv pip install "MIMIC-IV-MEDS==0.0.1" -c compat/constraints/0.0.1.txt
+meds-transforms==0.0.9

--- a/compat/constraints/0.0.2.txt
+++ b/compat/constraints/0.0.2.txt
@@ -1,0 +1,8 @@
+# Constraints that make MIMIC-IV-MEDS 0.0.2 run again.
+#
+# Why: declares bare 'meds-transforms' (unbounded); same failure as 0.0.1
+#
+# Verified 2026-08-05 by building the MIMIC-IV demo cohort end to end on Python 3.12.
+# Usage:
+#   uv pip install "MIMIC-IV-MEDS==0.0.2" -c compat/constraints/0.0.2.txt
+meds-transforms==0.0.9

--- a/compat/constraints/0.0.3.txt
+++ b/compat/constraints/0.0.3.txt
@@ -1,0 +1,8 @@
+# Constraints that make MIMIC-IV-MEDS 0.0.3 run again.
+#
+# Why: declares 'meds-transforms>=0.1' (unbounded above); same failure
+#
+# Verified 2026-08-05 by building the MIMIC-IV demo cohort end to end on Python 3.12.
+# Usage:
+#   uv pip install "MIMIC-IV-MEDS==0.0.3" -c compat/constraints/0.0.3.txt
+meds-transforms==0.1

--- a/compat/constraints/0.0.4.txt
+++ b/compat/constraints/0.0.4.txt
@@ -1,0 +1,8 @@
+# Constraints that make MIMIC-IV-MEDS 0.0.4 run again.
+#
+# Why: declares 'meds-transforms~=0.2', which means >=0.2,<1.0 and admits the 0.6.x that dropped MEDS_transforms.extract
+#
+# Verified 2026-08-05 by building the MIMIC-IV demo cohort end to end on Python 3.12.
+# Usage:
+#   uv pip install "MIMIC-IV-MEDS==0.0.4" -c compat/constraints/0.0.4.txt
+meds-transforms==0.2.1

--- a/compat/constraints/0.0.5.txt
+++ b/compat/constraints/0.0.5.txt
@@ -1,0 +1,8 @@
+# Constraints that make MIMIC-IV-MEDS 0.0.5 run again.
+#
+# Why: declared 'meds-transforms~=0.2.1' is correctly bounded; pinned here only to fix the exact upstream used
+#
+# Verified 2026-08-05 by building the MIMIC-IV demo cohort end to end on Python 3.12.
+# Usage:
+#   uv pip install "MIMIC-IV-MEDS==0.0.5" -c compat/constraints/0.0.5.txt
+meds-transforms==0.2.4

--- a/compat/constraints/0.0.6.txt
+++ b/compat/constraints/0.0.6.txt
@@ -1,0 +1,8 @@
+# Constraints that make MIMIC-IV-MEDS 0.0.6 run again.
+#
+# Why: declared pins are correct; recorded for exact reproducibility
+#
+# Verified 2026-08-05 by building the MIMIC-IV demo cohort end to end on Python 3.12.
+# Usage:
+#   uv pip install "MIMIC-IV-MEDS==0.0.6" -c compat/constraints/0.0.6.txt
+meds-transforms==0.2.4

--- a/compat/constraints/0.0.7.txt
+++ b/compat/constraints/0.0.7.txt
@@ -1,0 +1,8 @@
+# Constraints that make MIMIC-IV-MEDS 0.0.7 run again.
+#
+# Why: declared pins are correct; recorded for exact reproducibility
+#
+# Verified 2026-08-05 by building the MIMIC-IV demo cohort end to end on Python 3.12.
+# Usage:
+#   uv pip install "MIMIC-IV-MEDS==0.0.7" -c compat/constraints/0.0.7.txt
+meds-transforms==0.2.4

--- a/compat/constraints/0.1.0.txt
+++ b/compat/constraints/0.1.0.txt
@@ -1,0 +1,8 @@
+# Constraints that make MIMIC-IV-MEDS 0.1.0 run again.
+#
+# Why: declares 'meds-extract~=0.5', which means >=0.5,<1.0 and admits 0.6.x; 0.6.x routes code specs through dftly and rejects the YAML list form this config uses
+#
+# Verified 2026-08-05 by building the MIMIC-IV demo cohort end to end on Python 3.12.
+# Usage:
+#   uv pip install "MIMIC-IV-MEDS==0.1.0" -c compat/constraints/0.1.0.txt
+meds-extract==0.5.0

--- a/compat/constraints/0.1.1.txt
+++ b/compat/constraints/0.1.1.txt
@@ -1,0 +1,8 @@
+# Constraints that make MIMIC-IV-MEDS 0.1.1 run again.
+#
+# Why: same as 0.1.0
+#
+# Verified 2026-08-05 by building the MIMIC-IV demo cohort end to end on Python 3.12.
+# Usage:
+#   uv pip install "MIMIC-IV-MEDS==0.1.1" -c compat/constraints/0.1.1.txt
+meds-extract==0.5.0

--- a/compat/constraints/0.1.2.txt
+++ b/compat/constraints/0.1.2.txt
@@ -1,0 +1,8 @@
+# Constraints that make MIMIC-IV-MEDS 0.1.2 run again.
+#
+# Why: same as 0.1.0
+#
+# Verified 2026-08-05 by building the MIMIC-IV demo cohort end to end on Python 3.12.
+# Usage:
+#   uv pip install "MIMIC-IV-MEDS==0.1.2" -c compat/constraints/0.1.2.txt
+meds-extract==0.5.0


### PR DESCRIPTION
Addresses #66. **Targets `compat/historical-versions`, not `main` or `dev`** — see "Why not
main" below.

Seven of the ten released versions of this ETL do not install into a working pipeline today.
In every case the released **code is fine**; only the upstream specifier is wrong, so a
resolver run now picks a release years newer than the one the version was written against.

This PR does not change the ETL. It records, per released version, the upstream that actually
works, plus a script to build it — so a published version can still be rebuilt and audited.

```bash
compat/build_version.sh 0.1.2 /tmp/mimic-0.1.2
PATH="/tmp/mimic-0.1.2/.venv/bin:$PATH" \
  /tmp/mimic-0.1.2/.venv/bin/MEDS_extract-MIMIC_IV root_output_dir=$OUT do_demo=True
```

## What was wrong

| version | declared | resolves to | failure | works with |
|---|---|---|---|---|
| 0.0.1 | `meds-transforms` | 0.6.7 | `ModuleNotFoundError: MEDS_transforms.extract` | `==0.0.9` |
| 0.0.2 | `meds-transforms` | 0.6.7 | same | `==0.0.9` |
| 0.0.3 | `meds-transforms>=0.1` | 0.6.7 | same | `==0.1` |
| 0.0.4 | `meds-transforms~=0.2` | 0.6.7 | same | `==0.2.1` |
| 0.0.5–0.0.7 | `meds-transforms~=0.2.1` | 0.2.4 | ✅ works as declared | *(pinned for exactness)* |
| 0.1.0–0.1.2 | `meds-extract~=0.5` | 0.6.2 | `Failed to parse expression "['HCPCS', 'col(short_description)']"` | `meds-extract==0.5.0` |

Two distinct breakages: extraction moving out of MEDS-Transforms (so `MEDS_transforms.extract`
vanished), and MEDS-Extract 0.6 routing code specs through dftly's expression parser, which
rejects the YAML list form these configs use. I checked 0.6.1 as well — it fails identically to
0.6.2, so the boundary is 0.5 → 0.6, not a 0.6.2 regression.

`~=0.2.1` is the only specifier in the ETL's history that means what its author intended
(`>=0.2.1,<0.3`). **`~=0.2` and `~=0.5` both admit the next minor**, and both upstreams make
breaking changes across minors while pre-1.0.

## Verification

All ten versions installed from PyPI into isolated venvs against their constraints file, then
run against a **single cached copy** of PhysioNet `mimic-iv-demo/2.2` with downloading disabled
— byte-identical input for every version, so any output difference is attributable to the ETL
rather than to a re-download. All ten produce a valid MEDS cohort.

Their fingerprints are near-identical. The only movement in the entire published history:

| | 0.0.1–0.0.7 | 0.1.0–0.1.2 |
|---|---|---|
| n_events | 83,419 | 96,949 |
| n_measurements | 916,166 | 1,022,555 |
| n_unique_codes | 7,035 | 7,523 |

i.e. a deliberate expansion at 0.0.7 → 0.1.0 and nothing else. Ten releases, one behavioural
change. (Separately: every released version stamps `dataset_version: "3.1:<etl>"` onto a cohort
built from the **2.2** demo release — a mislabelling fixed only on the 0.7 branch.)

## Why not `main`

`main` is mid-migration to MEDS-Extract 0.7, where this ETL becomes pure config. Retro-fitting a
pin fix there would not help anyone trying to rebuild 0.0.3, and the diff would be meaningless
against these releases.

The real *forward* fix for consumers is either patch releases capping the upstream at the next
minor (`0.1.3` with `meds-extract>=0.5,<0.6`, etc.) or yanking the versions that cannot be
installed correctly. Both are maintainer calls, which is why this PR does neither. Until one
happens, `compat/` is the executable record of how to get each version running, and it costs
`main` nothing.

If you'd rather this live somewhere else — a docs page, a Gist, a `historical/` tag namespace —
say the word; the content is the useful part, not the location.
