### PR TITLE
Promote admission demographics to events; unfragment the DRG vocabulary

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,8 +115,11 @@ gradations attached to that assignment.
 
 ### Order modifiers
 
-`priority` (`ROUTINE` / `STAT`) joins the `LAB//*` codes: it is a categorical modifier of the
-order and belongs in the identity of what was measured. It is coalesced, being 4.8% null.
+`priority` (`ROUTINE` / `STAT`) joins the `LAB//SPECIMEN_COLLECTED` code only, not
+`LAB//RESULT`. Priority modifies how the specimen was collected; the result is simply what was
+observed, and is the same measurement however urgently it was drawn. Nothing is lost by leaving
+it off the result: `charttime` is never null across all 158M rows, so the collection event is
+always emitted. It is coalesced, being 4.8% null.
 
 `route` and `frequency` on `hosp/pharmacy` were considered for the same treatment and
 **deliberately left as extension columns**. Adding them takes `MEDICATION//START` from 22,539 to

--- a/README.md
+++ b/README.md
@@ -68,6 +68,68 @@ Everything the pipeline does is therefore inspectable — and modifiable — in 
 see [MEDS-Extract's documentation](https://github.com/mmcdermott/MEDS_extract) for the
 syntax.
 
+## What goes in the code, and what doesn't
+
+MIMIC carries a lot of columns that are neither the measurement nor metadata about it. Where
+each one lands is a modelling decision, so the reasoning is recorded here rather than in the
+config. All figures are from the full 3.1 release.
+
+### Demographics
+
+`insurance`, `language`, `marital_status` and `race` are properties of the subject, not
+annotations on the admission, so they are emitted as their own events (`INSURANCE//…`,
+`LANGUAGE//…`, `MARITAL_STATUS//…`, `RACE//…`) rather than carried as extension columns. MIMIC
+records no separate timestamp for them, so they are co-timed with the admission.
+
+Their nulls are **not** coalesced to `UNK`. A null code component drops the row under 0.7, so a
+missing demographic produces no event — which is the honest encoding, and avoids minting a
+`RACE//UNK` code that would read as an observed category. Null rates: insurance 1.71%, language
+0.14%, marital_status 2.49%, race 0%.
+
+### DRG
+
+**`drg_type: HCFA` means MS-DRG**, not the legacy CMS-DRG the name suggests. 302 distinct HCFA
+codes fall above 579, inside the MS-DRG-only numbering space (MS-DRG replaced CMS-DRG in FY2008;
+MIMIC-IV spans 2008–2022). `APR` is Solventum's proprietary APR-DRG. Both are genuine external
+classifications, so each code carries the bare identifier as a parent — `MS-DRG/003`,
+`APR-DRG/047` — via a `_self` metadata block.
+
+**`description` is not part of the code.** It is not a function of the code: 87.8% of HCFA
+`(drg_type, drg_code)` pairs carry more than one description, up to five, and the variants are
+spelling differences for the same DRG — `W MCC` vs `WITH MCC`, `&` vs `AND`, some truncated
+near 72 characters. Rendering it into the code split single DRGs across several MEDS codes and
+inflated the HCFA vocabulary **1.98×** (1,557 codes for 787 real DRGs). It rides in `text_value`
+instead, which keeps the string without letting MIMIC's spelling changes fragment the
+vocabulary.
+
+**`drg_severity` and `drg_mortality` stay extension columns.** They are the APR-DRG severity-of-
+illness and risk-of-mortality subclasses, computed by the grouper from the coded diagnoses —
+external model output, not something observed on the patient — so they are not MEDS
+measurements. They remain available for cohort selection. They are not redundant either: 278 of
+300 APR codes span all four severity levels, and knowing severity still leaves 66% of
+mortality's own entropy. Both are APR-only, hence null on every HCFA row.
+
+Note that the DRG code is itself grouper-assigned. What distinguishes it is that the DRG is an
+administrative fact with consequences — it is what was billed — whereas the subclasses are
+gradations attached to that assignment.
+
+### Order modifiers
+
+`priority` (`ROUTINE` / `STAT`) joins the `LAB//*` codes: it is a categorical modifier of the
+order and belongs in the identity of what was measured. It is coalesced, being 4.8% null.
+
+`route` and `frequency` on `hosp/pharmacy` were considered for the same treatment and
+**deliberately left as extension columns**. Adding them takes `MEDICATION//START` from 22,539 to
+125,381 codes — **5.56×**, with 56,248 singleton codes — and `frequency` alone accounts for
+4.53× of that across 177 values. That fragments the medication vocabulary far more than it
+sharpens it.
+
+`icu/inputevents` is untouched for related reasons: `ordercategorydescription` (5 values) and
+`statusdescription` (6 values) are closed enums rather than text, they cannot both occupy the
+single `text_value` slot on `input_end` (100% of rows carry both), and `rateuom` is 44.7% null
+so promoting it would stamp `UNK` into half of all `INFUSION_START` codes. See
+[#15](https://github.com/Medical-Event-Data-Standard/MIMIC_IV_MEDS/issues/15).
+
 ## Parallel and multi-node runs
 
 `meds-extract-run` runs the pipeline's stages serially. To parallelize, run the pipeline

--- a/src/MIMIC_IV_MEDS/configs/event_configs.yaml
+++ b/src/MIMIC_IV_MEDS/configs/event_configs.yaml
@@ -37,10 +37,24 @@ hosp/admissions:
   admission:
     code: f"HOSPITAL_ADMISSION//{$admission_type}//{$admission_location ?? 'UNK'}"
     time: '$admittime::"%Y-%m-%d %H:%M:%S"'
-    insurance: $insurance
-    language: $language
-    marital_status: $marital_status
-    race: $race
+    hadm_id: $hadm_id
+  # Nulls are deliberately not coalesced here: a missing demographic should produce no event
+  # rather than an `INSURANCE//UNK` code. See "Demographics" in the README.
+  insurance:
+    code: f"INSURANCE//{$insurance}"
+    time: '$admittime::"%Y-%m-%d %H:%M:%S"'
+    hadm_id: $hadm_id
+  language:
+    code: f"LANGUAGE//{$language}"
+    time: '$admittime::"%Y-%m-%d %H:%M:%S"'
+    hadm_id: $hadm_id
+  marital_status:
+    code: f"MARITAL_STATUS//{$marital_status}"
+    time: '$admittime::"%Y-%m-%d %H:%M:%S"'
+    hadm_id: $hadm_id
+  race:
+    code: f"RACE//{$race}"
+    time: '$admittime::"%Y-%m-%d %H:%M:%S"'
     hadm_id: $hadm_id
   discharge:
     code: f"HOSPITAL_DISCHARGE//{$discharge_location ?? 'UNK'}"
@@ -85,11 +99,19 @@ hosp/drgcodes:
         key: hadm_id
         cols: [dischtime]
   drg:
-    code: f"DRG//{$drg_type}//{$drg_code}//{$description ?? 'UNK'}"
+    code: f"DRG//{$drg_type}//{$drg_code}"
     hadm_id: $hadm_id
     time: '$dischtime::"%Y-%m-%d %H:%M:%S"'
+    text_value: $description
     drg_severity: $drg_severity
     drg_mortality: $drg_mortality
+    _metadata:
+      _self:
+        # `drg_code` is an Int64, so the canonical zero padding is gone: DRG 3 must render as
+        # `003`. dftly has no format specifiers and `len_chars` rejects an integer, hence the
+        # prefix-and-slice. `HCFA` denotes MS-DRG; see "DRG" in the README.
+        parent_codes: >-
+          f"{'MS-DRG' if $drg_type == 'HCFA' else 'APR-DRG'}/{f'000{$drg_code}'[-3:]}"
 
 hosp/emar:
   _table:
@@ -160,10 +182,9 @@ hosp/hcpcsevents:
 
 hosp/labevents:
   lab_specimen_collected:
-    code: 'f"LAB//SPECIMEN_COLLECTED//{$itemid}"'
+    code: 'f"LAB//SPECIMEN_COLLECTED//{$itemid}//{$priority ?? ''UNK''}"'
     hadm_id: $hadm_id
     time: '$charttime::"%Y-%m-%d %H:%M:%S"'
-    priority: $priority
     _metadata:
       d_labitems_to_loinc:
         # The join key is sourced from the differently-named raw column via the dftly
@@ -173,12 +194,11 @@ hosp/labevents:
         description: coalesce($omop_concept_name, $label)
         parent_codes: f"{$omop_vocabulary_id}/{$omop_concept_code}"
   lab_result:
-    code: f"LAB//RESULT//{$itemid}//{$valueuom ?? 'UNK'}"
+    code: f"LAB//RESULT//{$itemid}//{$valueuom ?? 'UNK'}//{$priority ?? 'UNK'}"
     hadm_id: $hadm_id
     time: '$storetime::"%Y-%m-%d %H:%M:%S"'
     numeric_value: $valuenum
     text_value: $value
-    priority: $priority
     _metadata:
       d_labitems_to_loinc:
         itemid:

--- a/src/MIMIC_IV_MEDS/configs/event_configs.yaml
+++ b/src/MIMIC_IV_MEDS/configs/event_configs.yaml
@@ -194,7 +194,7 @@ hosp/labevents:
         description: coalesce($omop_concept_name, $label)
         parent_codes: f"{$omop_vocabulary_id}/{$omop_concept_code}"
   lab_result:
-    code: f"LAB//RESULT//{$itemid}//{$valueuom ?? 'UNK'}//{$priority ?? 'UNK'}"
+    code: f"LAB//RESULT//{$itemid}//{$valueuom ?? 'UNK'}"
     hadm_id: $hadm_id
     time: '$storetime::"%Y-%m-%d %H:%M:%S"'
     numeric_value: $valuenum

--- a/tests/regression/demo_summary_stats.json
+++ b/tests/regression/demo_summary_stats.json
@@ -1,24 +1,24 @@
 {
   "code_metadata": {
     "description_length": {
-      "mean": 36.8127,
-      "n": 5360,
+      "mean": 36.2294,
+      "n": 5030,
       "quantiles": {
         "p1": 4.0,
-        "p25": 20.0,
+        "p25": 19.0,
         "p5": 8.0,
-        "p50": 33.0,
-        "p75": 49.25,
-        "p95": 79.0,
-        "p99": 110.0
+        "p50": 32.0,
+        "p75": 49.0,
+        "p95": 79.55,
+        "p99": 110.71
       },
-      "std": 23.1921
+      "std": 23.4387
     },
-    "n_codes": 10580,
+    "n_codes": 10249,
     "n_data_codes_missing_from_metadata": 0,
     "n_metadata_codes_absent_from_data": 0,
-    "n_with_description": 5360,
-    "n_with_parent_codes": 8208,
+    "n_with_description": 5030,
+    "n_with_parent_codes": 7899,
     "ontology": {
       "by_vocabulary": {
         "APR-DRG": {
@@ -63,7 +63,7 @@
         },
         "LOINC": {
           "keys_digest": "sha256:7e1025301545708e6a2084baa4f6c9d157fb51025441675ae468e9fa5c749d06",
-          "n_child_codes": 1712,
+          "n_child_codes": 1403,
           "n_distinct_keys": 540,
           "n_measurements": 424219,
           "n_subjects": 100,
@@ -118,24 +118,24 @@
         }
       },
       "coverage": {
-        "frac_measurements_mapped": 0.513962,
-        "frac_observed_codes_with_parents": 0.775803,
+        "frac_measurements_mapped": 0.513963,
+        "frac_observed_codes_with_parents": 0.770709,
         "n_measurements_mapped": 526774,
-        "n_measurements_unmapped": 498153,
-        "n_observed_codes": 10580,
-        "n_observed_codes_with_parents": 8208,
-        "n_observed_codes_without_parents": 2372
+        "n_measurements_unmapped": 498151,
+        "n_observed_codes": 10249,
+        "n_observed_codes_with_parents": 7899,
+        "n_observed_codes_without_parents": 2350
       },
       "n_codes_in_multiple_vocabularies": 0,
-      "n_codes_with_parents": 8208,
+      "n_codes_with_parents": 7899,
       "n_distinct_parents": 4006,
-      "n_parent_links": 8230,
+      "n_parent_links": 7921,
       "n_parents_without_vocabulary": 0,
       "n_vocabularies": 10,
       "n_vocabularies_recognized": 8,
       "parents_per_code": {
-        "mean": 0.777883,
-        "n": 10580,
+        "mean": 0.772856,
+        "n": 10249,
         "quantiles": {
           "p1": 0.0,
           "p25": 1.0,
@@ -145,12 +145,12 @@
           "p95": 1.0,
           "p99": 1.0
         },
-        "std": 0.420662
+        "std": 0.424099
       },
       "present": true,
       "vocabularies_per_code": {
-        "mean": 0.775803,
-        "n": 10580,
+        "mean": 0.770709,
+        "n": 10249,
         "quantiles": {
           "p1": 0.0,
           "p25": 1.0,
@@ -160,35 +160,35 @@
           "p95": 1.0,
           "p99": 1.0
         },
-        "std": 0.417072
+        "std": 0.420397
       }
     },
     "present": true,
-    "vocabulary_digest": "sha256:58f35951036a43f45c528247e8a6e1a2ba18fbcb7440b35cc87738555faf77a7"
+    "vocabulary_digest": "sha256:d7dff8f93f038af8f0725a67af5a00f5e24f3bae8850ddfd27e7a85d3c163bd5"
   },
   "codes": {
     "concentration": {
       "frac_measurements_in_top_10": 0.11812,
-      "frac_measurements_in_top_100": 0.380437,
-      "frac_measurements_in_top_1000": 0.894727,
-      "n_codes_covering_50pct": 174,
-      "n_codes_covering_90pct": 1046,
-      "n_codes_covering_99pct": 4752
+      "frac_measurements_in_top_100": 0.394857,
+      "frac_measurements_in_top_1000": 0.903672,
+      "n_codes_covering_50pct": 160,
+      "n_codes_covering_90pct": 969,
+      "n_codes_covering_99pct": 4523
     },
     "digests": {
-      "alphabetical": "sha256:58f35951036a43f45c528247e8a6e1a2ba18fbcb7440b35cc87738555faf77a7",
-      "by_measurement_frequency": "sha256:9a1f4452307bf36e6b74eb38b7a1a3858446ca175ede195c57ba09ddf758a166",
-      "by_subject_frequency": "sha256:3e017abc15454afebc3cf948d6c361b51b6aabc2350ae50aa331174e7d86a404",
+      "alphabetical": "sha256:d7dff8f93f038af8f0725a67af5a00f5e24f3bae8850ddfd27e7a85d3c163bd5",
+      "by_measurement_frequency": "sha256:df4715def1581b788d8126d9af68902ad9df8b93c0b755585442864ca859236f",
+      "by_subject_frequency": "sha256:20dabd49f8d8d7e44720f0145310e409f3f520bd91f97084f658755b9a04bd48",
       "numeric_moments": {
-        "digest": "sha256:768d34252328e96de5638916294f6adb40ec89ad91372587862b0a9551ed9cff",
-        "n_codes": 440
+        "digest": "sha256:2be85b0955221079f1da463dfdc0d3f8892f184ac8c38b78ecf06ec4275ae8a3",
+        "n_codes": 388
       },
       "thresholded": {
         "100": {
-          "alphabetical": "sha256:ab30b7321c3f5fdf11bd190ad32a32e805adfc5b5666970468c7124a36379d85",
-          "by_measurement_frequency": "sha256:9e426357e395433af4923a8330c3cb0e06939b9d16ec1b11117ff21ebb131985",
-          "by_subject_frequency": "sha256:ab30b7321c3f5fdf11bd190ad32a32e805adfc5b5666970468c7124a36379d85",
-          "n_codes": 48
+          "alphabetical": "sha256:96b4691809043202e421f93c09539b18cc39e4c27d2d5f9d61eedb9d150bcae1",
+          "by_measurement_frequency": "sha256:7efc9a37a6c51c0d07c9db308d6c2288364da47de908ea65753d096ae04b54df",
+          "by_subject_frequency": "sha256:96b4691809043202e421f93c09539b18cc39e4c27d2d5f9d61eedb9d150bcae1",
+          "n_codes": 70
         },
         "1000": {
           "alphabetical": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
@@ -197,43 +197,43 @@
           "n_codes": 0
         },
         "20": {
-          "alphabetical": "sha256:10382724b8630fc9d48a49714eb09e4db94ceb45db0364ee61eedb6efc787b93",
-          "by_measurement_frequency": "sha256:4373b57470cc071e725ec397736acb219ae3ca5e3fe015c1c776dd5ef6c2b5a1",
-          "by_subject_frequency": "sha256:9636741112231d0d14d04408c7730d622a7340265ec0cd223888766077f61c7b",
-          "n_codes": 1198
+          "alphabetical": "sha256:6f41a8ed73f481e2ab2533a55399f1f221a7ad6ca8347d9da7489b61e9bdabc8",
+          "by_measurement_frequency": "sha256:a7eeb874f51d7ead6f4c8bbd87320e930c567c9c1e79b4a1d717f99aa818ef8c",
+          "by_subject_frequency": "sha256:3e079ca804a16e1245287ee5a42efad73b6fd91f831641e690fe8a13f89b3181",
+          "n_codes": 1128
         }
       }
     },
-    "n_codes_below_min_cell_size": 9382,
-    "n_unique_codes": 10580,
+    "n_codes_below_min_cell_size": 9121,
+    "n_unique_codes": 10249,
     "occurrence": {
       "n_measurements": {
-        "mean": 96.874,
-        "n": 10580,
+        "mean": 100.002,
+        "n": 10249,
         "quantiles": {
           "p1": 1.0,
           "p25": 1.0,
           "p5": 1.0,
-          "p50": 4.0,
-          "p75": 18.0,
-          "p95": 425.0,
-          "p99": 1846.84
+          "p50": 3.0,
+          "p75": 17.0,
+          "p95": 402.0,
+          "p99": 2094.08
         },
-        "std": 525.573
+        "std": 541.773
       },
       "n_subjects": {
-        "mean": 8.70832,
-        "n": 10580,
+        "mean": 8.55996,
+        "n": 10249,
         "quantiles": {
           "p1": 1.0,
           "p25": 1.0,
           "p5": 1.0,
           "p50": 2.0,
           "p75": 5.0,
-          "p95": 53.0,
-          "p99": 98.0
+          "p95": 51.0,
+          "p99": 99.0
         },
-        "std": 18.4693
+        "std": 18.3184
       }
     }
   },
@@ -262,22 +262,22 @@
   },
   "counts": {
     "n_events": 96949,
-    "n_measurements": 1024927,
+    "n_measurements": 1024925,
     "n_static_measurements": 100,
     "n_subjects": 100,
     "n_subjects_with_birth": 100,
     "n_subjects_with_death": 31,
     "n_subjects_with_static": 100,
-    "n_unique_codes": 10580,
+    "n_unique_codes": 10249,
     "numeric": {
-      "mean": 80.5556,
-      "n_finite": 405331,
+      "mean": 80.556,
+      "n_finite": 405329,
       "n_infinite": 0,
       "n_nan": 0,
       "n_negative": 2920,
-      "n_present": 405331,
+      "n_present": 405329,
       "n_zero": 26220,
-      "std": 2483.12
+      "std": 2483.13
     },
     "quality": {
       "n_empty_code": 0,
@@ -286,7 +286,7 @@
     }
   },
   "dataset": {
-    "created_at": "2026-08-07T21:41:24.042649+00:00",
+    "created_at": "2026-08-07T21:48:40.459349+00:00",
     "dataset_name": "MIMIC-IV",
     "dataset_version": "2.2:0.1.1.dev47+g4018eceec.d20260807",
     "etl_name": "MEDS_transforms",
@@ -296,25 +296,25 @@
   },
   "dataset_digest": {
     "by_file": {
-      "data/held_out/0.parquet": "sha256:6e44e72c57c8fbdfaf96551fd29eb8884973e0f73e5254e58879c0a8b4952427",
-      "data/train/0.parquet": "sha256:79fbe6545148bcbc515847ee52ffdccfe9d470ec2ca28de5eeba5b95e5185975",
-      "data/tuning/0.parquet": "sha256:40a743df4a934a3a62820400f63060f6a58c884fd0bed5cc9ce180a2a988b1ce",
-      "metadata/codes.parquet": "sha256:710a1cb2c54bb2423643417277cacf1025a06542559507a777ddae187a39e359",
-      "metadata/dataset.json": "sha256:68c28cd158567d465fafc14e84bb5001c69ba13e99a40beb1d310609d8d7a819",
+      "data/held_out/0.parquet": "sha256:f93f9ee5de5ef37f2e9f0c480c883e49c1be9839bc96dc6994a7a668e88f611a",
+      "data/train/0.parquet": "sha256:efcdcd662d9e9742d49f8a2c54c5385f0a25086be806a3e0fc4d4a7d6e773d04",
+      "data/tuning/0.parquet": "sha256:22269e7c94666847f0ceb3ff992767f7ff3552e82accfb5b3a4de255ee296464",
+      "metadata/codes.parquet": "sha256:5fc2507c9d7093d6eb5f40c9e406ee54133884ef055acf406699ba25865b8221",
+      "metadata/dataset.json": "sha256:e470ea7ff926734218cb29e12432643ed70e389e6ad0bd53dbced087fcf05e9b",
       "metadata/subject_splits.parquet": "sha256:d5408b774b0cfb824ca0a98e1340151cf0ed6f822fcff5e8799f9770ac02d031"
     },
-    "code_metadata": "sha256:2df75cc21c6e3ca40547d61830df1851e25001ba7dcacee528fe1d872224ee5a",
-    "combined": "sha256:cb562b28ad324b0332bc26efd50ab0422f2a9941e78c80a7ba921ef3f5d6518b",
+    "code_metadata": "sha256:d8a5e91169fc6d0b3e2d85ba43ba93d5bc729f2223923ea969f3b54c442883f3",
+    "combined": "sha256:651348938f63c991b00550acba57f278bae4d82a1c80ca288d454eb69357042b",
     "data": {
-      "digest": "sha256:1e76e7a2f634029d4c50be5859b2736e8af610bc56facbb01a579800674be9bc",
+      "digest": "sha256:9ce11cdb301e32c6279f7274f67df63026abb1f59a788bb754fa8c9846e9ecd3",
       "n_files": 3
     },
-    "dataset_metadata": "sha256:48daef6ea7e9950de1c94e8021d617b1ab85906eee4daac1279e097994349764",
+    "dataset_metadata": "sha256:d4bb110763e9e73fe5ad0b1ac690030e98a27851272e166e2774e91949ec3ca1",
     "method": "files",
     "n_files": 6,
     "subject_splits": "sha256:a71fb24090a32d9bd7a6340095ebd483b4f13fb37d87f499f17955de538adf6f"
   },
-  "extracted_at": "2026-08-07T21:41:38.606909",
+  "extracted_at": "2026-08-07T21:48:41.797263",
   "layout": {
     "code_metadata_columns": {
       "code": "String",
@@ -418,7 +418,7 @@
       "std": 1097.27
     },
     "n_measurements": {
-      "mean": 10249.3,
+      "mean": 10249.2,
       "n": 100,
       "quantiles": {
         "p1": 1109.59,
@@ -429,21 +429,21 @@
         "p95": 38785.0,
         "p99": 49165.3
       },
-      "std": 12206.0
+      "std": 12205.9
     },
     "n_unique_codes": {
-      "mean": 921.34,
+      "mean": 877.31,
       "n": 100,
       "quantiles": {
-        "p1": 379.86,
-        "p25": 622.0,
-        "p5": 476.8,
-        "p50": 809.0,
-        "p75": 1033.0,
-        "p95": 1756.1,
-        "p99": 2190.18
+        "p1": 379.72,
+        "p25": 587.75,
+        "p5": 454.0,
+        "p50": 782.5,
+        "p75": 987.75,
+        "p95": 1641.15,
+        "p99": 2076.03
       },
-      "std": 412.915
+      "std": 390.709
     },
     "span_days": {
       "mean": 23298.5,
@@ -467,7 +467,7 @@
         "n_splits": 2
       },
       "train": {
-        "n_measurements": 901491,
+        "n_measurements": 901489,
         "n_subjects": 80
       }
     },
@@ -480,11 +480,11 @@
   "time": {
     "by_year": {
       "<suppressed>": {
-        "n_measurements": 1024827,
+        "n_measurements": 1024825,
         "n_years": 134
       }
     },
-    "n_measurements_with_time": 1024827,
+    "n_measurements_with_time": 1024825,
     "n_years_observed": 134
   }
 }

--- a/tests/regression/demo_summary_stats.json
+++ b/tests/regression/demo_summary_stats.json
@@ -1,26 +1,34 @@
 {
   "code_metadata": {
     "description_length": {
-      "mean": 35.7095,
-      "n": 4734,
+      "mean": 36.8127,
+      "n": 5360,
       "quantiles": {
         "p1": 4.0,
-        "p25": 19.0,
-        "p5": 8.65,
-        "p50": 30.0,
-        "p75": 48.0,
-        "p95": 80.0,
-        "p99": 112.0
+        "p25": 20.0,
+        "p5": 8.0,
+        "p50": 33.0,
+        "p75": 49.25,
+        "p95": 79.0,
+        "p99": 110.0
       },
-      "std": 23.6635
+      "std": 23.1921
     },
-    "n_codes": 9932,
+    "n_codes": 10580,
     "n_data_codes_missing_from_metadata": 0,
     "n_metadata_codes_absent_from_data": 0,
-    "n_with_description": 4734,
-    "n_with_parent_codes": 7373,
+    "n_with_description": 5360,
+    "n_with_parent_codes": 8208,
     "ontology": {
       "by_vocabulary": {
+        "APR-DRG": {
+          "keys_digest": "sha256:351f10257c5bfb811d245a14f0a51354761a5f5abb5c463270dbb6b28a7f23ae",
+          "n_child_codes": 110,
+          "n_distinct_keys": 110,
+          "n_measurements": 221,
+          "n_subjects": 98,
+          "recognized": false
+        },
         "ICD10CM": {
           "keys_digest": "sha256:13164fed20c59cd59b80f7c9c688626dfbfe64fb3cf00a2f75daf295aed3373b",
           "n_child_codes": 734,
@@ -55,7 +63,7 @@
         },
         "LOINC": {
           "keys_digest": "sha256:7e1025301545708e6a2084baa4f6c9d157fb51025441675ae468e9fa5c749d06",
-          "n_child_codes": 1135,
+          "n_child_codes": 1712,
           "n_distinct_keys": 540,
           "n_measurements": 424219,
           "n_subjects": 100,
@@ -65,6 +73,14 @@
             "std": 1311.38
           },
           "recognized": true
+        },
+        "MS-DRG": {
+          "keys_digest": "sha256:1b2837a140cff56ca637d79e3dd3003179038255905b3991dfff237416284d4d",
+          "n_child_codes": 148,
+          "n_distinct_keys": 148,
+          "n_measurements": 233,
+          "n_subjects": 100,
+          "recognized": false
         },
         "NDC": {
           "keys_digest": "sha256:7eaaa3e4e6d64a3136a555e6bb216158c7d448bb83669f8442bff6079b0de2cd",
@@ -102,77 +118,77 @@
         }
       },
       "coverage": {
-        "frac_measurements_mapped": 0.514065,
-        "frac_observed_codes_with_parents": 0.742348,
-        "n_measurements_mapped": 526320,
-        "n_measurements_unmapped": 497519,
-        "n_observed_codes": 9932,
-        "n_observed_codes_with_parents": 7373,
-        "n_observed_codes_without_parents": 2559
+        "frac_measurements_mapped": 0.513962,
+        "frac_observed_codes_with_parents": 0.775803,
+        "n_measurements_mapped": 526774,
+        "n_measurements_unmapped": 498153,
+        "n_observed_codes": 10580,
+        "n_observed_codes_with_parents": 8208,
+        "n_observed_codes_without_parents": 2372
       },
       "n_codes_in_multiple_vocabularies": 0,
-      "n_codes_with_parents": 7373,
-      "n_distinct_parents": 3748,
-      "n_parent_links": 7395,
+      "n_codes_with_parents": 8208,
+      "n_distinct_parents": 4006,
+      "n_parent_links": 8230,
       "n_parents_without_vocabulary": 0,
-      "n_vocabularies": 8,
+      "n_vocabularies": 10,
       "n_vocabularies_recognized": 8,
       "parents_per_code": {
-        "mean": 0.744563,
-        "n": 9932,
+        "mean": 0.777883,
+        "n": 10580,
         "quantiles": {
           "p1": 0.0,
-          "p25": 0.0,
+          "p25": 1.0,
           "p5": 0.0,
           "p50": 1.0,
           "p75": 1.0,
           "p95": 1.0,
           "p99": 1.0
         },
-        "std": 0.441179
+        "std": 0.420662
       },
       "present": true,
       "vocabularies_per_code": {
-        "mean": 0.742348,
-        "n": 9932,
+        "mean": 0.775803,
+        "n": 10580,
         "quantiles": {
           "p1": 0.0,
-          "p25": 0.0,
+          "p25": 1.0,
           "p5": 0.0,
           "p50": 1.0,
           "p75": 1.0,
           "p95": 1.0,
           "p99": 1.0
         },
-        "std": 0.437363
+        "std": 0.417072
       }
     },
     "present": true,
-    "vocabulary_digest": "sha256:08518dd479f1f29a7a61e86d75a9517a3e3f74b82cdcf9542c5ae0eb959f9d38"
+    "vocabulary_digest": "sha256:58f35951036a43f45c528247e8a6e1a2ba18fbcb7440b35cc87738555faf77a7"
   },
   "codes": {
     "concentration": {
-      "frac_measurements_in_top_10": 0.118245,
-      "frac_measurements_in_top_100": 0.405875,
-      "frac_measurements_in_top_1000": 0.91291,
-      "n_codes_covering_50pct": 147,
-      "n_codes_covering_90pct": 885,
-      "n_codes_covering_99pct": 4295
+      "frac_measurements_in_top_10": 0.11812,
+      "frac_measurements_in_top_100": 0.380437,
+      "frac_measurements_in_top_1000": 0.894727,
+      "n_codes_covering_50pct": 174,
+      "n_codes_covering_90pct": 1046,
+      "n_codes_covering_99pct": 4752
     },
     "digests": {
-      "alphabetical": "sha256:08518dd479f1f29a7a61e86d75a9517a3e3f74b82cdcf9542c5ae0eb959f9d38",
-      "by_measurement_frequency": "sha256:76198546f1452a367e132d67cbcea0ae60e5e1bfea53b4564885ff3ff81f063d",
-      "by_subject_frequency": "sha256:28aba787fed3bfb775c45efcb5ab1c89f4f7050a1a73ffdd395a792cb937cdf6",
+      "alphabetical": "sha256:58f35951036a43f45c528247e8a6e1a2ba18fbcb7440b35cc87738555faf77a7",
+      "by_measurement_frequency": "sha256:9a1f4452307bf36e6b74eb38b7a1a3858446ca175ede195c57ba09ddf758a166",
+      "by_subject_frequency": "sha256:3e017abc15454afebc3cf948d6c361b51b6aabc2350ae50aa331174e7d86a404",
       "numeric_moments": {
-        "digest": "sha256:c53316893a4bcaadfa44d9333babddcfc3faedebc46f7aabca7519e623c568a1",
-        "n_codes": 388
+        "digest": "sha256:768d34252328e96de5638916294f6adb40ec89ad91372587862b0a9551ed9cff",
+        "n_codes": 440
       },
       "thresholded": {
         "100": {
-          "alphabetical": "sha256:e824427af180a7de0737996afbe99a498fe0854095658ab7472c659a45519dcd",
-          "by_measurement_frequency": "sha256:681b7cc2d07be07847fc278a2cee9423a37a21f651c26fd87c6ebe16b635678a",
-          "by_subject_frequency": "sha256:e824427af180a7de0737996afbe99a498fe0854095658ab7472c659a45519dcd",
-          "n_codes": 93
+          "alphabetical": "sha256:ab30b7321c3f5fdf11bd190ad32a32e805adfc5b5666970468c7124a36379d85",
+          "by_measurement_frequency": "sha256:9e426357e395433af4923a8330c3cb0e06939b9d16ec1b11117ff21ebb131985",
+          "by_subject_frequency": "sha256:ab30b7321c3f5fdf11bd190ad32a32e805adfc5b5666970468c7124a36379d85",
+          "n_codes": 48
         },
         "1000": {
           "alphabetical": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
@@ -181,43 +197,43 @@
           "n_codes": 0
         },
         "20": {
-          "alphabetical": "sha256:45099ab573261950d85b113a23350a9cc5608ae110a6208e06f54a5c34f97a1d",
-          "by_measurement_frequency": "sha256:b914743f66fc511a4fce72097f8d2b75242987fee6d26b404ec44dc3e4b4a4dd",
-          "by_subject_frequency": "sha256:27968a21f1e1e33b0bd2a4e53c9add3595d53a3f1026827fc5b056fed96ee983",
-          "n_codes": 1056
+          "alphabetical": "sha256:10382724b8630fc9d48a49714eb09e4db94ceb45db0364ee61eedb6efc787b93",
+          "by_measurement_frequency": "sha256:4373b57470cc071e725ec397736acb219ae3ca5e3fe015c1c776dd5ef6c2b5a1",
+          "by_subject_frequency": "sha256:9636741112231d0d14d04408c7730d622a7340265ec0cd223888766077f61c7b",
+          "n_codes": 1198
         }
       }
     },
-    "n_codes_below_min_cell_size": 8876,
-    "n_unique_codes": 9932,
+    "n_codes_below_min_cell_size": 9382,
+    "n_unique_codes": 10580,
     "occurrence": {
       "n_measurements": {
-        "mean": 103.085,
-        "n": 9932,
+        "mean": 96.874,
+        "n": 10580,
         "quantiles": {
           "p1": 1.0,
           "p25": 1.0,
           "p5": 1.0,
-          "p50": 3.0,
-          "p75": 17.0,
-          "p95": 402.0,
-          "p99": 2376.69
+          "p50": 4.0,
+          "p75": 18.0,
+          "p95": 425.0,
+          "p99": 1846.84
         },
-        "std": 558.312
+        "std": 525.573
       },
       "n_subjects": {
-        "mean": 8.34948,
-        "n": 9932,
+        "mean": 8.70832,
+        "n": 10580,
         "quantiles": {
           "p1": 1.0,
           "p25": 1.0,
           "p5": 1.0,
           "p50": 2.0,
           "p75": 5.0,
-          "p95": 48.0,
-          "p99": 99.0
+          "p95": 53.0,
+          "p99": 98.0
         },
-        "std": 18.0937
+        "std": 18.4693
       }
     }
   },
@@ -246,13 +262,13 @@
   },
   "counts": {
     "n_events": 96949,
-    "n_measurements": 1023839,
+    "n_measurements": 1024927,
     "n_static_measurements": 100,
     "n_subjects": 100,
     "n_subjects_with_birth": 100,
     "n_subjects_with_death": 31,
     "n_subjects_with_static": 100,
-    "n_unique_codes": 9932,
+    "n_unique_codes": 10580,
     "numeric": {
       "mean": 80.5556,
       "n_finite": 405331,
@@ -270,9 +286,9 @@
     }
   },
   "dataset": {
-    "created_at": "2026-08-07T16:11:55.909092+00:00",
+    "created_at": "2026-08-07T21:41:24.042649+00:00",
     "dataset_name": "MIMIC-IV",
-    "dataset_version": "2.2:0.1.1.dev46+g909d60791",
+    "dataset_version": "2.2:0.1.1.dev47+g4018eceec.d20260807",
     "etl_name": "MEDS_transforms",
     "etl_version": "0.7.0",
     "meds_version": "0.4.1",
@@ -280,25 +296,25 @@
   },
   "dataset_digest": {
     "by_file": {
-      "data/held_out/0.parquet": "sha256:39fcc1c854783b0f088344e974f82f1c21ad5c0a90f37c8505e932b94031d5c7",
-      "data/train/0.parquet": "sha256:fb08073d8769f757fc546d192833e994d954055ce4a40255791bc1f246a67a9b",
-      "data/tuning/0.parquet": "sha256:f49c5f43c0a9145151608a6cceccb2f4c34f272094ec931c89427b864d305c25",
-      "metadata/codes.parquet": "sha256:6a48b764114203065a72369ca270012dccdf5ab26d5d8267053ae136258a6f58",
-      "metadata/dataset.json": "sha256:9b829ee326f5263fe5503f359f49a318fcebc2aa22acf9f26825ee881496e7d3",
+      "data/held_out/0.parquet": "sha256:6e44e72c57c8fbdfaf96551fd29eb8884973e0f73e5254e58879c0a8b4952427",
+      "data/train/0.parquet": "sha256:79fbe6545148bcbc515847ee52ffdccfe9d470ec2ca28de5eeba5b95e5185975",
+      "data/tuning/0.parquet": "sha256:40a743df4a934a3a62820400f63060f6a58c884fd0bed5cc9ce180a2a988b1ce",
+      "metadata/codes.parquet": "sha256:710a1cb2c54bb2423643417277cacf1025a06542559507a777ddae187a39e359",
+      "metadata/dataset.json": "sha256:68c28cd158567d465fafc14e84bb5001c69ba13e99a40beb1d310609d8d7a819",
       "metadata/subject_splits.parquet": "sha256:d5408b774b0cfb824ca0a98e1340151cf0ed6f822fcff5e8799f9770ac02d031"
     },
-    "code_metadata": "sha256:93718eea9a5fcff85220b48f98c1c0cf1b5648dec742c827cf0c04724655b5cf",
-    "combined": "sha256:cba50f43e3175717c890bf980dce570151ef92c15660475ef612bbdb3946f9de",
+    "code_metadata": "sha256:2df75cc21c6e3ca40547d61830df1851e25001ba7dcacee528fe1d872224ee5a",
+    "combined": "sha256:cb562b28ad324b0332bc26efd50ab0422f2a9941e78c80a7ba921ef3f5d6518b",
     "data": {
-      "digest": "sha256:921a1301df5b94a917291d662c746bd34efbea75b1f5b2037a3bac95b2312c2b",
+      "digest": "sha256:1e76e7a2f634029d4c50be5859b2736e8af610bc56facbb01a579800674be9bc",
       "n_files": 3
     },
-    "dataset_metadata": "sha256:822759c93ee43f2fb3f442fdbe665e8bc2a5c0e573645020e6d4ab15232b575e",
+    "dataset_metadata": "sha256:48daef6ea7e9950de1c94e8021d617b1ab85906eee4daac1279e097994349764",
     "method": "files",
     "n_files": 6,
     "subject_splits": "sha256:a71fb24090a32d9bd7a6340095ebd483b4f13fb37d87f499f17955de538adf6f"
   },
-  "extracted_at": "2026-08-07T16:12:07.773121",
+  "extracted_at": "2026-08-07T21:41:38.606909",
   "layout": {
     "code_metadata_columns": {
       "code": "String",
@@ -318,16 +334,11 @@
       "frequency": 3,
       "hadm_id": 3,
       "icustay_id": 3,
-      "insurance": 3,
-      "language": 3,
       "link_order_id": 3,
-      "marital_status": 3,
       "numeric_value": 3,
       "order_id": 3,
       "ordercategorydescription": 3,
       "poe_id": 3,
-      "priority": 3,
-      "race": 3,
       "route": 3,
       "source_block": 3,
       "statusdescription": 3,
@@ -346,16 +357,11 @@
       "frequency": "String",
       "hadm_id": "Int64",
       "icustay_id": "Int64",
-      "insurance": "String",
-      "language": "String",
       "link_order_id": "Int64",
-      "marital_status": "String",
       "numeric_value": "Float32",
       "order_id": "Int64",
       "ordercategorydescription": "String",
       "poe_id": "String",
-      "priority": "String",
-      "race": "String",
       "route": "String",
       "source_block": "String",
       "statusdescription": "String",
@@ -373,15 +379,10 @@
       "frequency",
       "hadm_id",
       "icustay_id",
-      "insurance",
-      "language",
       "link_order_id",
-      "marital_status",
       "order_id",
       "ordercategorydescription",
       "poe_id",
-      "priority",
-      "race",
       "route",
       "source_block",
       "statusdescription",
@@ -417,32 +418,32 @@
       "std": 1097.27
     },
     "n_measurements": {
-      "mean": 10238.4,
+      "mean": 10249.3,
       "n": 100,
       "quantiles": {
-        "p1": 1101.63,
-        "p25": 2680.0,
-        "p5": 1333.85,
-        "p50": 4704.5,
-        "p75": 11251.2,
-        "p95": 38757.2,
-        "p99": 49125.4
+        "p1": 1109.59,
+        "p25": 2687.5,
+        "p5": 1337.85,
+        "p50": 4712.5,
+        "p75": 11297.2,
+        "p95": 38785.0,
+        "p99": 49165.3
       },
-      "std": 12199.3
+      "std": 12206.0
     },
     "n_unique_codes": {
-      "mean": 829.27,
+      "mean": 921.34,
       "n": 100,
       "quantiles": {
-        "p1": 375.58,
-        "p25": 549.5,
-        "p5": 428.0,
-        "p50": 757.0,
-        "p75": 936.0,
-        "p95": 1537.4,
-        "p99": 1955.92
+        "p1": 379.86,
+        "p25": 622.0,
+        "p5": 476.8,
+        "p50": 809.0,
+        "p75": 1033.0,
+        "p95": 1756.1,
+        "p99": 2190.18
       },
-      "std": 369.627
+      "std": 412.915
     },
     "span_days": {
       "mean": 23298.5,
@@ -462,11 +463,11 @@
   "splits": {
     "by_split": {
       "<suppressed>": {
-        "n_measurements": 123292,
+        "n_measurements": 123436,
         "n_splits": 2
       },
       "train": {
-        "n_measurements": 900547,
+        "n_measurements": 901491,
         "n_subjects": 80
       }
     },
@@ -479,11 +480,11 @@
   "time": {
     "by_year": {
       "<suppressed>": {
-        "n_measurements": 1023739,
+        "n_measurements": 1024827,
         "n_years": 134
       }
     },
-    "n_measurements_with_time": 1023739,
+    "n_measurements_with_time": 1024827,
     "n_years_observed": 134
   }
 }


### PR DESCRIPTION
Implements the accepted parts of #15. Config change is 29 lines added, 9 removed; the
reasoning lives in a new README section rather than in the MESSY file.

## What changes in the data

Verified on the demo cohort. **Subjects and events are unchanged** (100 / 96,949) — nothing in
the clinical timeline moves.

| | before | after |
|---|---|---|
| measurements | 1,023,839 | 1,024,927 |
| unique codes | 9,932 | 10,580 |
| with a description | 4,734 | 5,360 |
| with `parent_codes` | 7,373 | 8,208 |
| data codes with no metadata row | 0 | 0 |

New parent vocabularies: **`MS-DRG`** and **`APR-DRG`**.

### Demographics become events

`insurance`, `language`, `marital_status`, `race` move from extension columns to their own
events (`INSURANCE//…` etc.), co-timed with the admission since MIMIC gives them no separate
timestamp.

Nulls are **not** coalesced. A null code component drops the row under 0.7, so a missing
demographic produces no event rather than a `RACE//UNK` code that would read as an observed
category. Null rates: insurance 1.71%, language 0.14%, marital_status 2.49%, race 0%.

### DRG description leaves the code

`description` was never a function of the code: **87.8% of HCFA `(drg_type, drg_code)` pairs
carry more than one description**, up to five, and the variants are spellings of the same DRG:

```
HCFA/32   'VENTRICULAR SHUNT PROCEDURES W CC'   vs  '… WITH CC'
HCFA/158  'DENTAL & ORAL DISEASES W CC'         vs  'DENTAL AND ORAL …'
HCFA/248  three variants, one truncated at ~72 characters
```

That inflated the HCFA vocabulary **1.98×** — 1,557 codes for 787 real DRGs — splitting patients
across MIMIC's wording changes. It now rides in `text_value`, which keeps the string without
fragmenting the vocabulary. In the demo, every DRG code resolves to exactly one parent and none
retains a description segment.

### DRG codes gain parents

Both families are real external classifications, so the bare identifier is a legitimate parent.
`drg_type: HCFA` is **MS-DRG**, not the legacy CMS-DRG the label suggests — 302 distinct HCFA
codes fall above 579, inside the MS-DRG-only numbering space (MS-DRG replaced CMS-DRG in FY2008;
MIMIC-IV spans 2008–2022).

`drg_code` is stored as `Int64`, so canonical zero-padding is lost and DRG 3 must be re-rendered
as `003` to match published tables — the same class of issue as the NDC leading-zero bug fixed
in #61.

### `priority` joins the LAB codes

A categorical modifier of the order, coalesced since it is 4.8% null.

## Deliberately not done

Each with the number behind it, recorded in the README so they don't get relitigated:

- **`drg_severity` / `drg_mortality` stay extension columns.** They are APR-DRG subclasses
  computed by the Solventum grouper from the coded diagnoses — external model output, not
  observations — so they are not MEDS measurements. Not redundant either: 278 of 300 APR codes
  span all four severity levels, and knowing severity leaves 66% of mortality's own entropy
  unexplained.
- **`route` / `frequency` stay extension columns.** Promoting them takes `MEDICATION//START`
  from 22,539 to **125,381 codes (5.56×)** with 56,248 singletons, almost entirely from
  `frequency`'s 177 values.
- **`icu/inputevents` untouched.** `ordercategorydescription` (5 values) and `statusdescription`
  (6 values) are closed enums rather than text; both are non-null on 100/100 sampled rows so
  they cannot share the single `text_value` slot on `input_end`; and `rateuom` is 44.7% null, so
  promoting it would stamp `UNK` into half of all `INFUSION_START` codes.

## Verification

Demo e2e passes against the released MEDS-Extract 0.7.0 wheel. Baseline regenerated in this
commit, so the summary-stats regression check reflects the new expected output.

Closes #15
